### PR TITLE
add filterPlaceholder to the README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ yarn add react-bs-datatable bootstrap-sass font-awesome
   - `show`: `string`. The text before select option of `rowsPerPageOption`.
   - `entries`: `string`. The text after select option of `rowsPerPageOption`.
   - `noResults`: `string`. Displayed text if table has empty `tableBody` or `[]`.
+  - `filterPlaceholder`: `string`. Placeholder text for filter input field.
 - tableClass: `string`. Classes used in `<table>` element tag. Default: `''`.
 - rowsPerPage: `number`. Initial rows per page. Default: `undefined`.
 - rowsPerPageOption: `number[]` for pagination options. Default: `undefined`.


### PR DESCRIPTION
Fixes https://github.com/Imballinst/react-bs-datatable/issues/49. This PR adds the missing documentation of `filterPlaceholder` in the README.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>