### PR TITLE
Remove unnecessary string assignment from Quantified value

### DIFF
--- a/src/helpers/data.ts
+++ b/src/helpers/data.ts
@@ -26,8 +26,8 @@ export function sortData<TTableRowType extends TableRowType>(
     let quantifiedValue2 = b[prop];
 
     if (sortFn) {
-      quantifiedValue1 = sortFn(`${quantifiedValue1}`);
-      quantifiedValue2 = sortFn(`${quantifiedValue2}`);
+      quantifiedValue1 = sortFn(quantifiedValue1);
+      quantifiedValue2 = sortFn(quantifiedValue2);
     }
 
     if (quantifiedValue1 < quantifiedValue2) {

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -113,7 +113,7 @@ export interface TableColumnType<T> {
  * can make the sort result incorrect, e.g. sorting formatted dates.
  */
 export type ColumnProcessObj<TColumnType, TReturnType = string> = Partial<
-  Record<keyof TColumnType, (column: string | number) => TReturnType>
+  Record<keyof TColumnType, (column: TColumnType) => TReturnType>
 >;
 
 /**


### PR DESCRIPTION
**Bug:** Sorting wasn't working when the row contains an object (was working in v2)
### **Example:** 
```
data=[
"name":{"firstname":"John", "lastname", "Doe"}, age: 42,
"name":{"firstname":"Agent", "lastname", "Smith"}, age: 49
]
```

we want to order by last name, we can send this with `sortProps`
```
    name: (value: any) => {
      return value.lastname;
    }
```

@imballinst This was working in v2, but I see you changed `sortFn(quantifiedValue1)` into ``sortFn(`${quantifiedValue1}`)``. 
Is there any specific reason for this change I'm missing?