### PR TITLE
Trigger Sort From Outside

### DIFF
--- a/src/components/DatatableWrapper.tsx
+++ b/src/components/DatatableWrapper.tsx
@@ -325,6 +325,16 @@ export function DatatableWrapper<TTableRowType = any>({
     []
   );
 
+  useEffect(() => {
+    setState((oldState) => ({
+      ...oldState,
+      sort: {
+        prop: sortProps?.initialState?.prop,
+        order: sortProps?.initialState?.order
+      }
+    }));
+  }, [sortProps]);
+
   const { filter, sort, pagination, isFilterable } = state;
   const { data, filteredDataLength, maxPage } = useMemo(() => {
     let newData = body;


### PR DESCRIPTION
**Need:** Trigger sort functionality from outside of the component
Changing `initialState` of the `sortProps` after initial render wasn't resorting, so I added a useEffect on sortProps change to force re-sort.

@imballinst

- Maybe I couldn't figure it out, was there a way actually do this?
- the prop name `initialState` implies the current behaviour correctly, so making it actually work after initial render sounds a little bit counter intuitive, should we define a new prop (but that will be crowding prop space unnecessarily), what i your opinion on this?
- Can you check the code for typescript type please, my ide is screaming at me, but I couldn't figure it out.