### PR TITLE
feat: implement `tableEventsRef` for calling control events outside of the uncontrolled table

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -2,37 +2,6 @@
 
 This document contains migration guide between major versions.
 
-## `react-bs-datatable@3.1`
-
-There is 1 breaking change if you are using a controlled table: `onSortChange` now receives the sorted prop, instead of the next sort state. So, if you are doing this right now:
-
-```ts
-const onSortChange = useCallback((nextSort: SortType) => {
-  setSortState(nextSort);
-}, []);
-```
-
-Change it to this:
-
-```ts
-const onSortChange = useCallback((sortedProp: string) => {
-  setSortState((oldState) => getNextSortState(oldState, sortedProp));
-}, []);
-```
-
-This `getNextSortState` is a newly exported helper function to easily "compute" the next sort:
-
-```ts
-export function getNextSortState(oldSort: SortType, sortedProp: string) {
-  const nextSort: SortType = { order: 'asc', prop: sortedProp };
-  if (sortedProp === oldSort.prop) {
-    nextSort.order = oldSort.order === 'asc' ? 'desc' : 'asc';
-  }
-
-  return nextSort;
-}
-```
-
 ## `react-bs-datatable@3`
 
 Bumping this library from v2 to v3 requires you to rewrite how the table JSX is written, as well as modifying a lot of dependencies. The changes are as the following.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -2,6 +2,37 @@
 
 This document contains migration guide between major versions.
 
+## `react-bs-datatable@3.1`
+
+There is 1 breaking change if you are using a controlled table: `onSortChange` now receives the sorted prop, instead of the next sort state. So, if you are doing this right now:
+
+```ts
+const onSortChange = useCallback((nextSort: SortType) => {
+  setSortState(nextSort);
+}, []);
+```
+
+Change it to this:
+
+```ts
+const onSortChange = useCallback((sortedProp: string) => {
+  setSortState((oldState) => getNextSortState(oldState, sortedProp));
+}, []);
+```
+
+This `getNextSortState` is a newly exported helper function to easily "compute" the next sort:
+
+```ts
+export function getNextSortState(oldSort: SortType, sortedProp: string) {
+  const nextSort: SortType = { order: 'asc', prop: sortedProp };
+  if (sortedProp === oldSort.prop) {
+    nextSort.order = oldSort.order === 'asc' ? 'desc' : 'asc';
+  }
+
+  return nextSort;
+}
+```
+
 ## `react-bs-datatable@3`
 
 Bumping this library from v2 to v3 requires you to rewrite how the table JSX is written, as well as modifying a lot of dependencies. The changes are as the following.

--- a/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlClasses.md
+++ b/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlClasses.md
@@ -24,4 +24,4 @@ This defaults to `link-primary text-decoration-none`.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/BulkCheckboxControl.tsx#L18)
+[components/BulkCheckboxControl.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/BulkCheckboxControl.tsx#L18)

--- a/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlProps.md
+++ b/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlProps.md
@@ -23,7 +23,7 @@ Custom classes for the component.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:41](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/BulkCheckboxControl.tsx#L41)
+[components/BulkCheckboxControl.tsx:41](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/BulkCheckboxControl.tsx#L41)
 
 ___
 
@@ -43,4 +43,4 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/BulkCheckboxControl.tsx#L26)
+[components/BulkCheckboxControl.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/BulkCheckboxControl.tsx#L26)

--- a/api/interfaces/components_DatatableWrapper.DatatableWrapperProps.md
+++ b/api/interfaces/components_DatatableWrapper.DatatableWrapperProps.md
@@ -25,6 +25,7 @@ The props that can be passed to the `DatatableWrapper` component.
 - [paginationOptionsProps](components_DatatableWrapper.DatatableWrapperProps.md#paginationoptionsprops)
 - [paginationProps](components_DatatableWrapper.DatatableWrapperProps.md#paginationprops)
 - [sortProps](components_DatatableWrapper.DatatableWrapperProps.md#sortprops)
+- [tableEventsRef](components_DatatableWrapper.DatatableWrapperProps.md#tableeventsref)
 
 ## Properties
 
@@ -34,7 +35,7 @@ The props that can be passed to the `DatatableWrapper` component.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:159](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L159)
+[components/DatatableWrapper.tsx:173](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L173)
 
 ___
 
@@ -44,7 +45,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:166](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L166)
+[components/DatatableWrapper.tsx:180](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L180)
 
 ___
 
@@ -56,7 +57,7 @@ The rest of the table, including its controls.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:157](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L157)
+[components/DatatableWrapper.tsx:171](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L171)
 
 ___
 
@@ -66,7 +67,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:162](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L162)
+[components/DatatableWrapper.tsx:176](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L176)
 
 ___
 
@@ -76,7 +77,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:158](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L158)
+[components/DatatableWrapper.tsx:172](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L172)
 
 ___
 
@@ -88,7 +89,7 @@ When set to `true`, the table will "skip" all uncontrolled processes.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:161](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L161)
+[components/DatatableWrapper.tsx:175](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L175)
 
 ___
 
@@ -98,7 +99,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:165](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L165)
+[components/DatatableWrapper.tsx:179](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L179)
 
 ___
 
@@ -108,7 +109,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:164](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L164)
+[components/DatatableWrapper.tsx:178](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L178)
 
 ___
 
@@ -118,4 +119,14 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:163](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L163)
+[components/DatatableWrapper.tsx:177](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L177)
+
+___
+
+### tableEventsRef
+
+• `Optional` **tableEventsRef**: `MutableRefObject`<`undefined` \| [`UncontrolledTableEvents`](components_DatatableWrapper.UncontrolledTableEvents.md)\>
+
+#### Defined in
+
+[components/DatatableWrapper.tsx:181](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L181)

--- a/api/interfaces/components_DatatableWrapper.TableCheckboxParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableCheckboxParameters.md
@@ -23,4 +23,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:106](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L106)
+[components/DatatableWrapper.tsx:112](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L112)

--- a/api/interfaces/components_DatatableWrapper.TableFilterParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableFilterParameters.md
@@ -29,4 +29,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L28)
+[components/DatatableWrapper.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L34)

--- a/api/interfaces/components_DatatableWrapper.TablePaginationOptionsParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TablePaginationOptionsParameters.md
@@ -30,4 +30,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:92](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L92)
+[components/DatatableWrapper.tsx:98](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L98)

--- a/api/interfaces/components_DatatableWrapper.TablePaginationParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TablePaginationParameters.md
@@ -30,4 +30,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:73](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L73)
+[components/DatatableWrapper.tsx:79](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L79)

--- a/api/interfaces/components_DatatableWrapper.TableSortParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableSortParameters.md
@@ -30,7 +30,7 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:64](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L64)
+[components/DatatableWrapper.tsx:70](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L70)
 
 ___
 
@@ -62,4 +62,4 @@ by number (milliseconds) instead of by formatted date string.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:62](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L62)
+[components/DatatableWrapper.tsx:68](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L68)

--- a/api/interfaces/components_DatatableWrapper.UncontrolledTableEvents.md
+++ b/api/interfaces/components_DatatableWrapper.UncontrolledTableEvents.md
@@ -1,0 +1,108 @@
+[react-bs-datatable](../README.md) / [components/DatatableWrapper](../modules/components_DatatableWrapper.md) / UncontrolledTableEvents
+
+# Interface: UncontrolledTableEvents
+
+[components/DatatableWrapper](../modules/components_DatatableWrapper.md).UncontrolledTableEvents
+
+## Table of contents
+
+### Properties
+
+- [onCheckboxChange](components_DatatableWrapper.UncontrolledTableEvents.md#oncheckboxchange)
+
+### Methods
+
+- [onFilterChange](components_DatatableWrapper.UncontrolledTableEvents.md#onfilterchange)
+- [onPaginationChange](components_DatatableWrapper.UncontrolledTableEvents.md#onpaginationchange)
+- [onRowsPerPageChange](components_DatatableWrapper.UncontrolledTableEvents.md#onrowsperpagechange)
+- [onSortChange](components_DatatableWrapper.UncontrolledTableEvents.md#onsortchange)
+
+## Properties
+
+### onCheckboxChange
+
+• **onCheckboxChange**: [`CheckboxOnChange`](../modules/helpers_types.md#checkboxonchange)
+
+#### Defined in
+
+[components/DatatableWrapper.tsx:120](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L120)
+
+## Methods
+
+### onFilterChange
+
+▸ **onFilterChange**(`nextState`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `nextState` | `string` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[components/DatatableWrapper.tsx:116](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L116)
+
+___
+
+### onPaginationChange
+
+▸ **onPaginationChange**(`nextState`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `nextState` | `number` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[components/DatatableWrapper.tsx:118](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L118)
+
+___
+
+### onRowsPerPageChange
+
+▸ **onRowsPerPageChange**(`nextState`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `nextState` | `number` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[components/DatatableWrapper.tsx:119](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L119)
+
+___
+
+### onSortChange
+
+▸ **onSortChange**(`sortedProp`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `sortedProp` | `string` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[components/DatatableWrapper.tsx:117](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L117)

--- a/api/interfaces/components_Filter.FilterClasses.md
+++ b/api/interfaces/components_Filter.FilterClasses.md
@@ -25,7 +25,7 @@ The class for the clear button.
 
 #### Defined in
 
-[components/Filter.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Filter.tsx#L19)
+[components/Filter.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Filter.tsx#L19)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the text input.
 
 #### Defined in
 
-[components/Filter.tsx:17](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Filter.tsx#L17)
+[components/Filter.tsx:17](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Filter.tsx#L17)
 
 ___
 
@@ -50,4 +50,4 @@ text input and the clear button.
 
 #### Defined in
 
-[components/Filter.tsx:15](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Filter.tsx#L15)
+[components/Filter.tsx:15](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Filter.tsx#L15)

--- a/api/interfaces/components_Filter.FilterProps.md
+++ b/api/interfaces/components_Filter.FilterProps.md
@@ -24,7 +24,7 @@ Custom classes for the component.
 
 #### Defined in
 
-[components/Filter.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Filter.tsx#L32)
+[components/Filter.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Filter.tsx#L32)
 
 ___
 
@@ -43,7 +43,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/Filter.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Filter.tsx#L34)
+[components/Filter.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Filter.tsx#L34)
 
 ___
 
@@ -56,4 +56,4 @@ By default, the text is "Enter text...".
 
 #### Defined in
 
-[components/Filter.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Filter.tsx#L30)
+[components/Filter.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Filter.tsx#L30)

--- a/api/interfaces/components_Pagination.PaginationClasses.md
+++ b/api/interfaces/components_Pagination.PaginationClasses.md
@@ -24,7 +24,7 @@ The class for each of the pagination button.
 
 #### Defined in
 
-[components/Pagination.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L25)
+[components/Pagination.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L25)
 
 ___
 
@@ -36,4 +36,4 @@ The class for the pagination button group.
 
 #### Defined in
 
-[components/Pagination.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L27)
+[components/Pagination.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L27)

--- a/api/interfaces/components_Pagination.PaginationLabels.md
+++ b/api/interfaces/components_Pagination.PaginationLabels.md
@@ -25,7 +25,7 @@ The "First" button label. Defaults to "First".
 
 #### Defined in
 
-[components/Pagination.tsx:10](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L10)
+[components/Pagination.tsx:10](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L10)
 
 ___
 
@@ -37,7 +37,7 @@ The "Last" button label. Defaults to "Last".
 
 #### Defined in
 
-[components/Pagination.tsx:12](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L12)
+[components/Pagination.tsx:12](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L12)
 
 ___
 
@@ -49,7 +49,7 @@ The "Next" button label. Defaults to "Next".
 
 #### Defined in
 
-[components/Pagination.tsx:16](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L16)
+[components/Pagination.tsx:16](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L16)
 
 ___
 
@@ -61,4 +61,4 @@ The "Prev" button label. Defaults to "Prev".
 
 #### Defined in
 
-[components/Pagination.tsx:14](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L14)
+[components/Pagination.tsx:14](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L14)

--- a/api/interfaces/components_Pagination.PaginationProps.md
+++ b/api/interfaces/components_Pagination.PaginationProps.md
@@ -28,7 +28,7 @@ To prevent layout shifts, `visibility: hidden` will be applied instead of
 
 #### Defined in
 
-[components/Pagination.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L44)
+[components/Pagination.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L44)
 
 ___
 
@@ -40,7 +40,7 @@ Customize the classes of the `Pagination` component.
 
 #### Defined in
 
-[components/Pagination.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L37)
+[components/Pagination.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L37)
 
 ___
 
@@ -60,7 +60,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/Pagination.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L46)
+[components/Pagination.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L46)
 
 ___
 
@@ -72,4 +72,4 @@ Customize the labels of the `Pagination` component.
 
 #### Defined in
 
-[components/Pagination.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L35)
+[components/Pagination.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L35)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsClasses.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsClasses.md
@@ -25,7 +25,7 @@ The class for the select input.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L35)
+[components/PaginationOptions.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L35)
 
 ___
 
@@ -38,7 +38,7 @@ the `beforeSelect` label, the select input, and the `afterSelect` text.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:31](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L31)
+[components/PaginationOptions.tsx:31](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L31)
 
 ___
 
@@ -50,4 +50,4 @@ The class for the `beforeSelect` and `afterSelect` labels.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:33](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L33)
+[components/PaginationOptions.tsx:33](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L33)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsLabels.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsLabels.md
@@ -25,7 +25,7 @@ is a horizontal form instead of vertical (e.g. using `flex-direction: row`).
 
 #### Defined in
 
-[components/PaginationOptions.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L19)
+[components/PaginationOptions.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L19)
 
 ___
 
@@ -38,4 +38,4 @@ Defaults to "Rows per page".
 
 #### Defined in
 
-[components/PaginationOptions.tsx:13](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L13)
+[components/PaginationOptions.tsx:13](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L13)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsProps.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsProps.md
@@ -28,7 +28,7 @@ To prevent layout shifts, `visibility: hidden` will be applied instead of
 
 #### Defined in
 
-[components/PaginationOptions.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L52)
+[components/PaginationOptions.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L52)
 
 ___
 
@@ -40,7 +40,7 @@ Customize the classes of the `PaginationOptions` component.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L45)
+[components/PaginationOptions.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L45)
 
 ___
 
@@ -61,7 +61,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:54](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L54)
+[components/PaginationOptions.tsx:54](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L54)
 
 ___
 
@@ -73,4 +73,4 @@ Customize the labels of the `PaginationOptions` component.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:43](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L43)
+[components/PaginationOptions.tsx:43](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L43)

--- a/api/interfaces/components_TableBody.TableBodyClasses.md
+++ b/api/interfaces/components_TableBody.TableBodyClasses.md
@@ -25,7 +25,7 @@ The class for the `tbody` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableBody.tsx#L28)
+[components/TableBody.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableBody.tsx#L28)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the `td` tags inside each `tr` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableBody.tsx#L32)
+[components/TableBody.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableBody.tsx#L32)
 
 ___
 
@@ -49,4 +49,4 @@ The class for the `tr` tags inside `tbody`.
 
 #### Defined in
 
-[components/TableBody.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableBody.tsx#L30)
+[components/TableBody.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableBody.tsx#L30)

--- a/api/interfaces/components_TableBody.TableBodyLabels.md
+++ b/api/interfaces/components_TableBody.TableBodyLabels.md
@@ -23,4 +23,4 @@ no data (empty array), or no matching found for the filtered text.
 
 #### Defined in
 
-[components/TableBody.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableBody.tsx#L19)
+[components/TableBody.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableBody.tsx#L19)

--- a/api/interfaces/components_TableBody.TableBodyProps.md
+++ b/api/interfaces/components_TableBody.TableBodyProps.md
@@ -34,7 +34,7 @@ Customize the classes of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:42](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableBody.tsx#L42)
+[components/TableBody.tsx:42](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableBody.tsx#L42)
 
 ___
 
@@ -54,7 +54,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/TableBody.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableBody.tsx#L46)
+[components/TableBody.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableBody.tsx#L46)
 
 ___
 
@@ -66,7 +66,7 @@ Customize the labels of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:40](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableBody.tsx#L40)
+[components/TableBody.tsx:40](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableBody.tsx#L40)
 
 ## Methods
 
@@ -88,4 +88,4 @@ The function fired when any of the rows is clicked.
 
 #### Defined in
 
-[components/TableBody.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableBody.tsx#L44)
+[components/TableBody.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableBody.tsx#L44)

--- a/api/interfaces/components_TableHeader.TableHeaderClasses.md
+++ b/api/interfaces/components_TableHeader.TableHeaderClasses.md
@@ -25,7 +25,7 @@ The class for the `th` tags inside each `tr` tag.
 
 #### Defined in
 
-[components/TableHeader.tsx:29](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableHeader.tsx#L29)
+[components/TableHeader.tsx:29](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableHeader.tsx#L29)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the `thead` tag.
 
 #### Defined in
 
-[components/TableHeader.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableHeader.tsx#L25)
+[components/TableHeader.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableHeader.tsx#L25)
 
 ___
 
@@ -49,4 +49,4 @@ The class for the `tr` tags inside `tbody`.
 
 #### Defined in
 
-[components/TableHeader.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableHeader.tsx#L27)
+[components/TableHeader.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableHeader.tsx#L27)

--- a/api/interfaces/components_TableHeader.TableHeaderProps.md
+++ b/api/interfaces/components_TableHeader.TableHeaderProps.md
@@ -23,7 +23,7 @@ Customize the classes of the `TableHeader` component.
 
 #### Defined in
 
-[components/TableHeader.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableHeader.tsx#L37)
+[components/TableHeader.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableHeader.tsx#L37)
 
 ___
 
@@ -41,8 +41,8 @@ Props to make the component controlled.
 | `filteredDataLength?` | `number` | The filtered data length. When not using filter control, then this should equal to the table body's length. |
 | `onCheckboxChange?` | [`CheckboxOnChange`](../modules/helpers_types.md#checkboxonchange) | The function fired when any checkbox in the table changes. |
 | `sortState?` | [`SortType`](helpers_types.SortType.md) | The current sort state of the table. |
-| `onSortChange?` | (`nextSort`: [`SortType`](helpers_types.SortType.md)) => `void` | The function fired when the table sort state changes. |
+| `onSortChange?` | (`sortedProp`: `string`) => `void` | The function fired when the table sort state changes. |
 
 #### Defined in
 
-[components/TableHeader.tsx:39](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableHeader.tsx#L39)
+[components/TableHeader.tsx:39](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableHeader.tsx#L39)

--- a/api/interfaces/helpers_types.CheckboxState.md
+++ b/api/interfaces/helpers_types.CheckboxState.md
@@ -25,7 +25,7 @@ the behavior of the `Set` type.
 
 #### Defined in
 
-[helpers/types.ts:25](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L25)
+[helpers/types.ts:25](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L25)
 
 ___
 
@@ -38,4 +38,4 @@ The checkbox states. This is useful to determine the "Select all" and
 
 #### Defined in
 
-[helpers/types.ts:30](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L30)
+[helpers/types.ts:30](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L30)

--- a/api/interfaces/helpers_types.SortType.md
+++ b/api/interfaces/helpers_types.SortType.md
@@ -23,7 +23,7 @@ The sort order.
 
 #### Defined in
 
-[helpers/types.ts:13](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L13)
+[helpers/types.ts:13](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L13)
 
 ___
 
@@ -36,4 +36,4 @@ This is the same as `header.prop` from `TableColumnType` interface.
 
 #### Defined in
 
-[helpers/types.ts:11](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L11)
+[helpers/types.ts:11](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L11)

--- a/api/interfaces/helpers_types.TableColumnType.md
+++ b/api/interfaces/helpers_types.TableColumnType.md
@@ -48,7 +48,7 @@ the same thing.
 
 #### Defined in
 
-[helpers/types.ts:100](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L100)
+[helpers/types.ts:100](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L100)
 
 ___
 
@@ -67,7 +67,7 @@ The props passed to the table columns under `tbody`.
 
 #### Defined in
 
-[helpers/types.ts:63](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L63)
+[helpers/types.ts:63](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L63)
 
 ___
 
@@ -87,7 +87,7 @@ the column will be a checkbox, both the headers and the rest of the rows.
 
 #### Defined in
 
-[helpers/types.ts:89](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L89)
+[helpers/types.ts:89](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L89)
 
 ___
 
@@ -101,7 +101,7 @@ will not be rendered.
 
 #### Defined in
 
-[helpers/types.ts:80](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L80)
+[helpers/types.ts:80](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L80)
 
 ___
 
@@ -113,7 +113,7 @@ Determines whether the column is sortable or not.
 
 #### Defined in
 
-[helpers/types.ts:84](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L84)
+[helpers/types.ts:84](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L84)
 
 ___
 
@@ -127,7 +127,7 @@ have unique `prop` field.
 
 #### Defined in
 
-[helpers/types.ts:53](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L53)
+[helpers/types.ts:53](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L53)
 
 ___
 
@@ -139,7 +139,7 @@ The title for the header.
 
 #### Defined in
 
-[helpers/types.ts:55](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L55)
+[helpers/types.ts:55](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L55)
 
 ## Methods
 
@@ -161,7 +161,7 @@ Custom render the table body cell. This is a function with the row data as param
 
 #### Defined in
 
-[helpers/types.ts:61](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L61)
+[helpers/types.ts:61](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L61)
 
 ___
 
@@ -184,4 +184,4 @@ Custom render the table header cell.
 
 #### Defined in
 
-[helpers/types.ts:57](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L57)
+[helpers/types.ts:57](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L57)

--- a/api/modules/components_BulkCheckboxControl.md
+++ b/api/modules/components_BulkCheckboxControl.md
@@ -38,4 +38,4 @@ change to "Deselect all" button.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/BulkCheckboxControl.tsx#L52)
+[components/BulkCheckboxControl.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/BulkCheckboxControl.tsx#L52)

--- a/api/modules/components_DatatableWrapper.md
+++ b/api/modules/components_DatatableWrapper.md
@@ -12,6 +12,7 @@
 - [TablePaginationOptionsParameters](../interfaces/components_DatatableWrapper.TablePaginationOptionsParameters.md)
 - [TablePaginationParameters](../interfaces/components_DatatableWrapper.TablePaginationParameters.md)
 - [TableSortParameters](../interfaces/components_DatatableWrapper.TableSortParameters.md)
+- [UncontrolledTableEvents](../interfaces/components_DatatableWrapper.UncontrolledTableEvents.md)
 
 ### Functions
 
@@ -41,4 +42,4 @@
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:199](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/DatatableWrapper.tsx#L199)
+[components/DatatableWrapper.tsx:214](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/DatatableWrapper.tsx#L214)

--- a/api/modules/components_Filter.md
+++ b/api/modules/components_Filter.md
@@ -35,4 +35,4 @@ prop. Otherwise, this component will return `null`.
 
 #### Defined in
 
-[components/Filter.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Filter.tsx#L47)
+[components/Filter.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Filter.tsx#L47)

--- a/api/modules/components_Pagination.md
+++ b/api/modules/components_Pagination.md
@@ -41,4 +41,4 @@ When `alwaysShowPagination` is set to `false`, then this component will be visua
 
 #### Defined in
 
-[components/Pagination.tsx:70](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/Pagination.tsx#L70)
+[components/Pagination.tsx:70](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/Pagination.tsx#L70)

--- a/api/modules/components_PaginationOptions.md
+++ b/api/modules/components_PaginationOptions.md
@@ -42,4 +42,4 @@ When `alwaysShowPagination` is set to `false`, then this component will be visua
 
 #### Defined in
 
-[components/PaginationOptions.tsx:80](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/PaginationOptions.tsx#L80)
+[components/PaginationOptions.tsx:80](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/PaginationOptions.tsx#L80)

--- a/api/modules/components_TableBody.md
+++ b/api/modules/components_TableBody.md
@@ -41,4 +41,4 @@ such as `tr` and `td` tags.
 
 #### Defined in
 
-[components/TableBody.tsx:66](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableBody.tsx#L66)
+[components/TableBody.tsx:66](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableBody.tsx#L66)

--- a/api/modules/components_TableHeader.md
+++ b/api/modules/components_TableHeader.md
@@ -33,4 +33,4 @@ Renders a list of table headers.
 
 #### Defined in
 
-[components/TableHeader.tsx:62](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/components/TableHeader.tsx#L62)
+[components/TableHeader.tsx:62](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/components/TableHeader.tsx#L62)

--- a/api/modules/helpers_data.md
+++ b/api/modules/helpers_data.md
@@ -1,3 +1,32 @@
 [react-bs-datatable](../README.md) / helpers/data
 
 # Module: helpers/data
+
+## Table of contents
+
+### Functions
+
+- [getNextSortState](helpers_data.md#getnextsortstate)
+
+## Functions
+
+### getNextSortState
+
+▸ **getNextSortState**(`oldSort`, `sortedProp`): [`SortType`](../interfaces/helpers_types.SortType.md)
+
+This is a helper function to get the next sort state.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `oldSort` | [`SortType`](../interfaces/helpers_types.SortType.md) |
+| `sortedProp` | `string` |
+
+#### Returns
+
+[`SortType`](../interfaces/helpers_types.SortType.md)
+
+#### Defined in
+
+[helpers/data.ts:119](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/data.ts#L119)

--- a/api/modules/helpers_types.md
+++ b/api/modules/helpers_types.md
@@ -44,7 +44,7 @@ The helper type to declare the checkbox onChange handler safely.
 
 #### Defined in
 
-[helpers/types.ts:36](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L36)
+[helpers/types.ts:36](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L36)
 
 ___
 
@@ -68,7 +68,7 @@ can make the sort result incorrect, e.g. sorting formatted dates.
 
 #### Defined in
 
-[helpers/types.ts:115](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L115)
+[helpers/types.ts:115](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L115)
 
 ___
 
@@ -86,4 +86,4 @@ This is used for the `extend` keyword in the components.
 
 #### Defined in
 
-[helpers/types.ts:122](https://github.com/imballinst/react-bs-datatable/blob/6be73b6/src/helpers/types.ts#L122)
+[helpers/types.ts:122](https://github.com/imballinst/react-bs-datatable/blob/eac35b9/src/helpers/types.ts#L122)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bs-datatable",
-  "version": "3.0.2-alpha.0",
+  "version": "3.1.0-alpha.0",
   "description": "React Bootstrap Datatable (without jQuery) with sorting, filter, and pagination",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/__stories__/00-Uncontrolled.stories.tsx
+++ b/src/__stories__/00-Uncontrolled.stories.tsx
@@ -149,10 +149,14 @@ const RefTemplate: ComponentStory<typeof StoryTable> = (args) => {
   const tableEventsRef = useRef<UncontrolledTableEvents>();
   return (
     <div>
-      <button onClick={() => tableEventsRef.current?.onSortChange('name')}>
+      <button
+        onClick={() => tableEventsRef.current?.onSortByPropChange('name')}
+      >
         External sort by name
       </button>
-      <button onClick={() => tableEventsRef.current?.onSortChange('username')}>
+      <button
+        onClick={() => tableEventsRef.current?.onSortByPropChange('username')}
+      >
         External sort by username
       </button>
       <StoryTable {...args} tableEventsRef={tableEventsRef} />

--- a/src/__stories__/00-Uncontrolled.stories.tsx
+++ b/src/__stories__/00-Uncontrolled.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MutableRefObject, useRef } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Col, Row, Table } from 'react-bootstrap';
 import { parse } from 'date-fns';
@@ -10,7 +10,8 @@ import { TableHeader } from '../components/TableHeader';
 import { TableBody, TableBodyProps } from '../components/TableBody';
 import {
   DatatableWrapper,
-  DatatableWrapperProps
+  DatatableWrapperProps,
+  UncontrolledTableEvents
 } from '../components/DatatableWrapper';
 import { Filter } from '../components/Filter';
 import { PaginationOptions } from '../components/PaginationOptions';
@@ -144,6 +145,32 @@ RowOnClick.argTypes = {
   }
 };
 
+const RefTemplate: ComponentStory<typeof StoryTable> = (args) => {
+  const tableEventsRef = useRef<UncontrolledTableEvents>();
+  return (
+    <div>
+      <button onClick={() => tableEventsRef.current?.onSortChange('name')}>
+        External sort by name
+      </button>
+      <button onClick={() => tableEventsRef.current?.onSortChange('username')}>
+        External sort by username
+      </button>
+      <StoryTable {...args} tableEventsRef={tableEventsRef} />
+    </div>
+  );
+};
+
+export const UncontrolledWithRefEvents = RefTemplate.bind({});
+UncontrolledWithRefEvents.storyName =
+  'Uncontrolled table with external sort events trigger';
+UncontrolledWithRefEvents.args = {
+  sortableFields: ['Name', 'Username', 'Last Update', 'Score'],
+  filterableFields: ['Name', 'Username', 'Location'],
+  alwaysShowPagination: true,
+  rowsPerPage: 10,
+  rowsPerPageOptions: [5, 10, 15, 20]
+};
+
 // Components.
 const SORT_PROPS: DatatableWrapperProps<StoryColumnType>['sortProps'] = {
   sortValueObj: {
@@ -170,7 +197,8 @@ function StoryTable({
   scoreCellColumnColor,
   // For on click row event.
   rowOnClickText,
-  rowOnClickFn
+  rowOnClickFn,
+  tableEventsRef
 }: {
   sortableFields?: string[];
   filterableFields?: string[];
@@ -191,6 +219,9 @@ function StoryTable({
   // For on click row event.
   rowOnClickText?: string;
   rowOnClickFn?: (name: string) => void;
+  // Set this to `true` if we want to control the table events from outside,
+  // but keep the table uncontrolled.
+  tableEventsRef?: MutableRefObject<UncontrolledTableEvents | undefined>;
 }) {
   const headers: TableColumnType<StoryColumnType>[] = STORY_HEADERS.map(
     (header) => ({
@@ -242,6 +273,7 @@ function StoryTable({
       body={json}
       headers={headers}
       sortProps={SORT_PROPS}
+      tableEventsRef={tableEventsRef}
       paginationOptionsProps={{
         initialState: {
           rowsPerPage,

--- a/src/__stories__/01-Controlled.stories.tsx
+++ b/src/__stories__/01-Controlled.stories.tsx
@@ -14,6 +14,7 @@ import { Filter } from '../components/Filter';
 import { PaginationOptions } from '../components/PaginationOptions';
 import { Pagination } from '../components/Pagination';
 import { SortType, TableColumnType } from '../helpers/types';
+import { getNextSortState } from '../helpers/data';
 
 export default {
   /* 👇 The title prop is optional.
@@ -100,8 +101,8 @@ function AsyncStoryTable<TTableRowType = any>({
     setCurrentPage(1);
   }, []);
 
-  const onSortChange = useCallback((nextSort: SortType) => {
-    setSortState(nextSort);
+  const onSortChange = useCallback((sortedProp: string) => {
+    setSortState((oldState) => getNextSortState(oldState, sortedProp));
   }, []);
 
   const onPaginationChange = useCallback((nextPage) => {

--- a/src/__stories__/01-Controlled.stories.tsx
+++ b/src/__stories__/01-Controlled.stories.tsx
@@ -101,8 +101,8 @@ function AsyncStoryTable<TTableRowType = any>({
     setCurrentPage(1);
   }, []);
 
-  const onSortChange = useCallback((sortedProp: string) => {
-    setSortState((oldState) => getNextSortState(oldState, sortedProp));
+  const onSortChange = useCallback((nextProp: SortType) => {
+    setSortState(nextProp);
   }, []);
 
   const onPaginationChange = useCallback((nextPage) => {

--- a/src/components/DatatableWrapper.tsx
+++ b/src/components/DatatableWrapper.tsx
@@ -359,6 +359,8 @@ export function DatatableWrapper<TTableRowType = any>({
   // Imperative handle.
   // This is if we want to keep the table events controllable from outside,
   // without making the table controlled.
+  // TODO(imballinst): rethink about this for the next major version (4.x).
+  // https://github.com/imballinst/react-bs-datatable/pull/123#issuecomment-1050582200.
   useImperativeHandle(
     tableEventsRef,
     () => ({

--- a/src/components/DatatableWrapper.tsx
+++ b/src/components/DatatableWrapper.tsx
@@ -20,6 +20,10 @@ import {
   CheckboxOnChange,
   CheckboxState,
   ColumnProcessObj,
+  FilterOnChange,
+  PaginationOnChange,
+  RowsPerPageOnChange,
+  SortByPropOnChange,
   SortType,
   TableRowType
 } from '../helpers/types';
@@ -113,10 +117,10 @@ export interface TableCheckboxParameters {
 }
 
 export interface UncontrolledTableEvents {
-  onFilterChange: (nextState: string) => void;
-  onSortChange: (sortedProp: string) => void;
-  onPaginationChange: (nextState: number) => void;
-  onRowsPerPageChange: (nextState: number) => void;
+  onFilterChange: FilterOnChange;
+  onSortByPropChange: SortByPropOnChange;
+  onPaginationChange: PaginationOnChange;
+  onRowsPerPageChange: RowsPerPageOnChange;
   onCheckboxChange: CheckboxOnChange;
 }
 
@@ -134,7 +138,8 @@ interface DatatableWrapperContextType<TTableRowType> {
   onFilterChange: (nextState: string) => void;
   // Sort.
   sortState: SortType;
-  onSortChange: (sortedProp: string) => void;
+  onSortChange: (nextProp: SortType) => void;
+  onSortByPropChange: (sortedProp: string) => void;
   // Pagination.
   currentPageState: number;
   onPaginationChange: (nextState: number) => void;
@@ -315,7 +320,14 @@ export function DatatableWrapper<TTableRowType = any>({
     }));
   }, []);
 
-  const onSortChange = useCallback((sortedProp: string) => {
+  const onSortChange = useCallback((nextSort: SortType) => {
+    setState((oldState) => ({
+      ...oldState,
+      sort: nextSort
+    }));
+  }, []);
+
+  const onSortByPropChange = useCallback((sortedProp: string) => {
     setState((oldState) => ({
       ...oldState,
       sort: getNextSortState(oldState.sort, sortedProp)
@@ -353,7 +365,7 @@ export function DatatableWrapper<TTableRowType = any>({
       onFilterChange,
       onPaginationChange,
       onRowsPerPageChange,
-      onSortChange,
+      onSortByPropChange,
       onCheckboxChange
     }),
     []
@@ -403,6 +415,7 @@ export function DatatableWrapper<TTableRowType = any>({
         // Sort.
         sortState: sort,
         onSortChange,
+        onSortByPropChange,
         // Pagination.
         currentPageState: pagination.currentPage,
         onPaginationChange,

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { InputGroup, Form, Button } from 'react-bootstrap';
+import { FilterOnChange } from '../helpers/types';
 import { useDatatableWrapper } from './DatatableWrapper';
 import FontAwesome from './FontAwesome';
 
@@ -35,7 +36,7 @@ export interface FilterProps {
     /** The text filter. */
     filter?: string;
     /** The function fired when the text filter changes. */
-    onFilter?: (nextFilter: string) => void;
+    onFilter?: FilterOnChange;
   };
 }
 

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, ButtonGroup } from 'react-bootstrap';
 
 import { makeClasses } from '../helpers/object';
+import { PaginationOnChange } from '../helpers/types';
 import { useDatatableWrapper } from './DatatableWrapper';
 
 /** This is an interface to customize the pagination labels. */
@@ -53,7 +54,7 @@ export interface PaginationProps {
      */
     maxPage?: number;
     /** The function fired when any of the pagination buttons is clicked. */
-    onPaginationChange?: (nextPage: number) => void;
+    onPaginationChange?: PaginationOnChange;
   };
 }
 

--- a/src/components/PaginationOptions.tsx
+++ b/src/components/PaginationOptions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Form } from 'react-bootstrap';
 
 import { makeClasses } from '../helpers/object';
+import { RowsPerPageOnChange } from '../helpers/types';
 import { useDatatableWrapper } from './DatatableWrapper';
 
 /** This is an interface to customize the pagination options labels. */
@@ -62,7 +63,7 @@ export interface PaginationOptionsProps {
      */
     filteredDataLength?: number;
     /** The function fired when any of the pagination option is changed. */
-    onRowsPerPageChange?: (nextRowsPerPage: number) => void;
+    onRowsPerPageChange?: RowsPerPageOnChange;
   };
 }
 

--- a/src/components/TableHeader.tsx
+++ b/src/components/TableHeader.tsx
@@ -38,7 +38,7 @@ export interface TableHeaderProps {
   /** Props to make the component controlled. */
   controlledProps?: {
     /** The function fired when the table sort state changes. */
-    onSortChange?: (nextSort: SortType) => void;
+    onSortChange?: (sortedProp: string) => void;
     /** The current sort state of the table. */
     sortState?: SortType;
     /** The function fired when any checkbox in the table changes. */
@@ -95,7 +95,6 @@ export function TableHeader({ classes, controlledProps }: TableHeaderProps) {
       'thead-th': true,
       sortable: isSortable === true
     });
-    const nextSort: SortType = { order: 'asc', prop };
     const isCurrentSort = sortState.prop === prop;
     const thProps: Record<string, any> = {
       key: `th-${i}`,
@@ -122,13 +121,12 @@ export function TableHeader({ classes, controlledProps }: TableHeaderProps) {
 
         if (sortState.order === 'asc') {
           sortIcon = 'sortUp';
-          nextSort.order = 'desc';
         } else {
           sortIcon = 'sortDown';
         }
       }
 
-      thProps.onClick = () => onSortChange(nextSort);
+      thProps.onClick = () => onSortChange(prop);
       thProps.role = 'button';
 
       sortIconRender = <FontAwesome icon={sortIcon} className="fa-fw" />;

--- a/src/components/TableHeader.tsx
+++ b/src/components/TableHeader.tsx
@@ -5,16 +5,16 @@ import { useDatatableWrapper } from './DatatableWrapper';
 import FontAwesome from './FontAwesome';
 import { makeClasses } from '../helpers/object';
 import {
-  TableColumnType,
   SortType,
-  TableRowType,
   CheckboxState,
-  CheckboxOnChange
+  CheckboxOnChange,
+  SortOnChange
 } from '../helpers/types';
 import {
   getNextCheckboxState,
   GetNextCheckboxStateParams
 } from '../helpers/checkbox';
+import { getNextSortState } from '../helpers/data';
 
 /**
  * This is an interface for customizing the classes for
@@ -38,7 +38,7 @@ export interface TableHeaderProps {
   /** Props to make the component controlled. */
   controlledProps?: {
     /** The function fired when the table sort state changes. */
-    onSortChange?: (sortedProp: string) => void;
+    onSortChange?: SortOnChange;
     /** The current sort state of the table. */
     sortState?: SortType;
     /** The function fired when any checkbox in the table changes. */
@@ -126,7 +126,7 @@ export function TableHeader({ classes, controlledProps }: TableHeaderProps) {
         }
       }
 
-      thProps.onClick = () => onSortChange(prop);
+      thProps.onClick = () => onSortChange(getNextSortState(sortState, prop));
       thProps.role = 'button';
 
       sortIconRender = <FontAwesome icon={sortIcon} className="fa-fw" />;

--- a/src/helpers/data.ts
+++ b/src/helpers/data.ts
@@ -114,6 +114,8 @@ export function paginateData<TTableRowType extends TableRowType>(
 }
 
 /**
+ * @internal
+ *
  * This is a helper function to get the next sort state.
  */
 export function getNextSortState(oldSort: SortType, sortedProp: string) {

--- a/src/helpers/data.ts
+++ b/src/helpers/data.ts
@@ -112,3 +112,15 @@ export function paginateData<TTableRowType extends TableRowType>(
 
   return paginatedData;
 }
+
+/**
+ * This is a helper function to get the next sort state.
+ */
+export function getNextSortState(oldSort: SortType, sortedProp: string) {
+  const nextSort: SortType = { order: 'asc', prop: sortedProp };
+  if (sortedProp === oldSort.prop) {
+    nextSort.order = oldSort.order === 'asc' ? 'desc' : 'asc';
+  }
+
+  return nextSort;
+}

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -31,16 +31,6 @@ export interface CheckboxState {
 }
 
 /**
- * The helper type to declare the checkbox onChange handler safely.
- */
-export type CheckboxOnChange = (params: {
-  prop: string;
-  idProp: string;
-  nextCheckboxState: CheckboxState;
-  checkboxRefs: MutableRefObject<Record<string, HTMLInputElement>>;
-}) => void;
-
-/**
  * The data structure of a table column, which will be used for the `headers`
  * prop of the `DatatableWrapper` props, as well as the `TableHeader` props.
  */
@@ -120,3 +110,40 @@ export type ColumnProcessObj<TColumnType, TReturnType = string> = Partial<
  * This is used for the `extend` keyword in the components.
  */
 export type TableRowType<T = any> = Record<string, T>;
+
+// Table events.
+
+/**
+ * The helper type for the filter change event.
+ */
+export type FilterOnChange = (nextState: string) => void;
+
+/**
+ * The helper type for the sort by next prop change event.
+ */
+export type SortOnChange = (nextProp: SortType) => void;
+
+/**
+ * The helper type for the sort by prop change event.
+ */
+export type SortByPropOnChange = (sortedProp: string) => void;
+
+/**
+ * The helper type for the sort by prop change event.
+ */
+export type PaginationOnChange = (nextState: number) => void;
+
+/**
+ * The helper type for the rows per page change event.
+ */
+export type RowsPerPageOnChange = (nextState: number) => void;
+
+/**
+ * The helper type for the checkbox change eveent.
+ */
+export type CheckboxOnChange = (params: {
+  prop: string;
+  idProp: string;
+  nextCheckboxState: CheckboxState;
+  checkboxRefs: MutableRefObject<Record<string, HTMLInputElement>>;
+}) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export type {
 export { BulkCheckboxControl } from './components/BulkCheckboxControl';
 export type { BulkCheckboxControlProps } from './components/BulkCheckboxControl';
 
+export { getNextSortState } from './helpers/data';
+
 export type {
   ColumnProcessObj,
   SortType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,6 @@ export type {
 export { BulkCheckboxControl } from './components/BulkCheckboxControl';
 export type { BulkCheckboxControlProps } from './components/BulkCheckboxControl';
 
-export { getNextSortState } from './helpers/data';
-
 export type {
   ColumnProcessObj,
   SortType,


### PR DESCRIPTION
This follows the idea in https://github.com/imballinst/react-bs-datatable/pull/123#issuecomment-1050421625, with 1 change:

1. Use `onSortByPropChange` to be passed to the `useImperativeHandle` and keep `onSortChange` as it is. This is because, if we change `onSortChange`, then it will be a breaking change.

I tried a different approach to use a hook outside of `DatatableWrapper`, but the changes were quite big and of course, breaking. I don't want to make the table API unstable, so I'll leave it for the future.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>