### PR TITLE
feature: export `useDatatableWrapper` from entry point

### DIFF
--- a/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlClasses.md
+++ b/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlClasses.md
@@ -24,4 +24,4 @@ This defaults to `link-primary text-decoration-none`.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/BulkCheckboxControl.tsx#L18)
+[components/BulkCheckboxControl.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/BulkCheckboxControl.tsx#L18)

--- a/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlClasses.md
+++ b/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlClasses.md
@@ -24,4 +24,4 @@ This defaults to `link-primary text-decoration-none`.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/BulkCheckboxControl.tsx#L18)
+[components/BulkCheckboxControl.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/BulkCheckboxControl.tsx#L18)

--- a/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlProps.md
+++ b/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlProps.md
@@ -23,7 +23,7 @@ Custom classes for the component.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:41](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/BulkCheckboxControl.tsx#L41)
+[components/BulkCheckboxControl.tsx:41](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/BulkCheckboxControl.tsx#L41)
 
 ___
 
@@ -43,4 +43,4 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/BulkCheckboxControl.tsx#L26)
+[components/BulkCheckboxControl.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/BulkCheckboxControl.tsx#L26)

--- a/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlProps.md
+++ b/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlProps.md
@@ -23,7 +23,7 @@ Custom classes for the component.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:41](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/BulkCheckboxControl.tsx#L41)
+[components/BulkCheckboxControl.tsx:41](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/BulkCheckboxControl.tsx#L41)
 
 ___
 
@@ -43,4 +43,4 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/BulkCheckboxControl.tsx#L26)
+[components/BulkCheckboxControl.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/BulkCheckboxControl.tsx#L26)

--- a/api/interfaces/components_DatatableWrapper.DatatableWrapperProps.md
+++ b/api/interfaces/components_DatatableWrapper.DatatableWrapperProps.md
@@ -35,7 +35,7 @@ The props that can be passed to the `DatatableWrapper` component.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:178](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L178)
+[components/DatatableWrapper.tsx:178](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L178)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:185](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L185)
+[components/DatatableWrapper.tsx:185](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L185)
 
 ___
 
@@ -57,7 +57,7 @@ The rest of the table, including its controls.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:176](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L176)
+[components/DatatableWrapper.tsx:176](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L176)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:181](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L181)
+[components/DatatableWrapper.tsx:181](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L181)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:177](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L177)
+[components/DatatableWrapper.tsx:177](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L177)
 
 ___
 
@@ -89,7 +89,7 @@ When set to `true`, the table will "skip" all uncontrolled processes.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:180](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L180)
+[components/DatatableWrapper.tsx:180](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L180)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:184](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L184)
+[components/DatatableWrapper.tsx:184](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L184)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:183](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L183)
+[components/DatatableWrapper.tsx:183](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L183)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:182](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L182)
+[components/DatatableWrapper.tsx:182](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L182)
 
 ___
 
@@ -127,6 +127,11 @@ ___
 
 • `Optional` **tableEventsRef**: `MutableRefObject`<`undefined` \| [`UncontrolledTableEvents`](components_DatatableWrapper.UncontrolledTableEvents.md)\>
 
+**`deprecated`**
+
+Usage of `tableEventsRef` is deprecated. Consider using `useDatatableWrapper`
+and raising the `DatatableWrapper` a bit higher in the structure instead.
+
 #### Defined in
 
-[components/DatatableWrapper.tsx:186](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L186)
+[components/DatatableWrapper.tsx:192](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L192)

--- a/api/interfaces/components_DatatableWrapper.DatatableWrapperProps.md
+++ b/api/interfaces/components_DatatableWrapper.DatatableWrapperProps.md
@@ -35,7 +35,7 @@ The props that can be passed to the `DatatableWrapper` component.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:178](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L178)
+[components/DatatableWrapper.tsx:178](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L178)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:185](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L185)
+[components/DatatableWrapper.tsx:185](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L185)
 
 ___
 
@@ -57,7 +57,7 @@ The rest of the table, including its controls.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:176](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L176)
+[components/DatatableWrapper.tsx:176](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L176)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:181](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L181)
+[components/DatatableWrapper.tsx:181](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L181)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:177](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L177)
+[components/DatatableWrapper.tsx:177](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L177)
 
 ___
 
@@ -89,7 +89,7 @@ When set to `true`, the table will "skip" all uncontrolled processes.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:180](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L180)
+[components/DatatableWrapper.tsx:180](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L180)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:184](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L184)
+[components/DatatableWrapper.tsx:184](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L184)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:183](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L183)
+[components/DatatableWrapper.tsx:183](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L183)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:182](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L182)
+[components/DatatableWrapper.tsx:182](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L182)
 
 ___
 
@@ -129,4 +129,4 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:186](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L186)
+[components/DatatableWrapper.tsx:186](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L186)

--- a/api/interfaces/components_DatatableWrapper.TableCheckboxParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableCheckboxParameters.md
@@ -23,4 +23,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:116](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L116)
+[components/DatatableWrapper.tsx:116](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L116)

--- a/api/interfaces/components_DatatableWrapper.TableCheckboxParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableCheckboxParameters.md
@@ -23,4 +23,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:116](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L116)
+[components/DatatableWrapper.tsx:116](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L116)

--- a/api/interfaces/components_DatatableWrapper.TableFilterParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableFilterParameters.md
@@ -29,4 +29,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L38)
+[components/DatatableWrapper.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L38)

--- a/api/interfaces/components_DatatableWrapper.TableFilterParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableFilterParameters.md
@@ -29,4 +29,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L38)
+[components/DatatableWrapper.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L38)

--- a/api/interfaces/components_DatatableWrapper.TablePaginationOptionsParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TablePaginationOptionsParameters.md
@@ -30,4 +30,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:102](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L102)
+[components/DatatableWrapper.tsx:102](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L102)

--- a/api/interfaces/components_DatatableWrapper.TablePaginationOptionsParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TablePaginationOptionsParameters.md
@@ -30,4 +30,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:102](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L102)
+[components/DatatableWrapper.tsx:102](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L102)

--- a/api/interfaces/components_DatatableWrapper.TablePaginationParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TablePaginationParameters.md
@@ -30,4 +30,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:83](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L83)
+[components/DatatableWrapper.tsx:83](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L83)

--- a/api/interfaces/components_DatatableWrapper.TablePaginationParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TablePaginationParameters.md
@@ -30,4 +30,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:83](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L83)
+[components/DatatableWrapper.tsx:83](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L83)

--- a/api/interfaces/components_DatatableWrapper.TableSortParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableSortParameters.md
@@ -30,7 +30,7 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:74](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L74)
+[components/DatatableWrapper.tsx:74](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L74)
 
 ___
 
@@ -62,4 +62,4 @@ by number (milliseconds) instead of by formatted date string.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:72](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L72)
+[components/DatatableWrapper.tsx:72](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L72)

--- a/api/interfaces/components_DatatableWrapper.TableSortParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableSortParameters.md
@@ -30,7 +30,7 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:74](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L74)
+[components/DatatableWrapper.tsx:74](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L74)
 
 ___
 
@@ -62,4 +62,4 @@ by number (milliseconds) instead of by formatted date string.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:72](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L72)
+[components/DatatableWrapper.tsx:72](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L72)

--- a/api/interfaces/components_DatatableWrapper.UncontrolledTableEvents.md
+++ b/api/interfaces/components_DatatableWrapper.UncontrolledTableEvents.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:124](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L124)
+[components/DatatableWrapper.tsx:124](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L124)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:120](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L120)
+[components/DatatableWrapper.tsx:120](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L120)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:122](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L122)
+[components/DatatableWrapper.tsx:122](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L122)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:123](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L123)
+[components/DatatableWrapper.tsx:123](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L123)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:121](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L121)
+[components/DatatableWrapper.tsx:121](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L121)

--- a/api/interfaces/components_DatatableWrapper.UncontrolledTableEvents.md
+++ b/api/interfaces/components_DatatableWrapper.UncontrolledTableEvents.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:124](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L124)
+[components/DatatableWrapper.tsx:124](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L124)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:120](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L120)
+[components/DatatableWrapper.tsx:120](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L120)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:122](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L122)
+[components/DatatableWrapper.tsx:122](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L122)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:123](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L123)
+[components/DatatableWrapper.tsx:123](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L123)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:121](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L121)
+[components/DatatableWrapper.tsx:121](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L121)

--- a/api/interfaces/components_Filter.FilterClasses.md
+++ b/api/interfaces/components_Filter.FilterClasses.md
@@ -25,7 +25,7 @@ The class for the clear button.
 
 #### Defined in
 
-[components/Filter.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L20)
+[components/Filter.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Filter.tsx#L20)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the text input.
 
 #### Defined in
 
-[components/Filter.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L18)
+[components/Filter.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Filter.tsx#L18)
 
 ___
 
@@ -50,4 +50,4 @@ text input and the clear button.
 
 #### Defined in
 
-[components/Filter.tsx:16](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L16)
+[components/Filter.tsx:16](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Filter.tsx#L16)

--- a/api/interfaces/components_Filter.FilterClasses.md
+++ b/api/interfaces/components_Filter.FilterClasses.md
@@ -25,7 +25,7 @@ The class for the clear button.
 
 #### Defined in
 
-[components/Filter.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Filter.tsx#L20)
+[components/Filter.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L20)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the text input.
 
 #### Defined in
 
-[components/Filter.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Filter.tsx#L18)
+[components/Filter.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L18)
 
 ___
 
@@ -50,4 +50,4 @@ text input and the clear button.
 
 #### Defined in
 
-[components/Filter.tsx:16](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Filter.tsx#L16)
+[components/Filter.tsx:16](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L16)

--- a/api/interfaces/components_Filter.FilterProps.md
+++ b/api/interfaces/components_Filter.FilterProps.md
@@ -24,7 +24,7 @@ Custom classes for the component.
 
 #### Defined in
 
-[components/Filter.tsx:33](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L33)
+[components/Filter.tsx:33](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Filter.tsx#L33)
 
 ___
 
@@ -43,7 +43,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/Filter.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L35)
+[components/Filter.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Filter.tsx#L35)
 
 ___
 
@@ -56,4 +56,4 @@ By default, the text is "Enter text...".
 
 #### Defined in
 
-[components/Filter.tsx:31](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L31)
+[components/Filter.tsx:31](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Filter.tsx#L31)

--- a/api/interfaces/components_Filter.FilterProps.md
+++ b/api/interfaces/components_Filter.FilterProps.md
@@ -24,7 +24,7 @@ Custom classes for the component.
 
 #### Defined in
 
-[components/Filter.tsx:33](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Filter.tsx#L33)
+[components/Filter.tsx:33](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L33)
 
 ___
 
@@ -43,7 +43,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/Filter.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Filter.tsx#L35)
+[components/Filter.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L35)
 
 ___
 
@@ -56,4 +56,4 @@ By default, the text is "Enter text...".
 
 #### Defined in
 
-[components/Filter.tsx:31](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Filter.tsx#L31)
+[components/Filter.tsx:31](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L31)

--- a/api/interfaces/components_Pagination.PaginationClasses.md
+++ b/api/interfaces/components_Pagination.PaginationClasses.md
@@ -24,7 +24,7 @@ The class for each of the pagination button.
 
 #### Defined in
 
-[components/Pagination.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L26)
+[components/Pagination.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L26)
 
 ___
 
@@ -36,4 +36,4 @@ The class for the pagination button group.
 
 #### Defined in
 
-[components/Pagination.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L28)
+[components/Pagination.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L28)

--- a/api/interfaces/components_Pagination.PaginationClasses.md
+++ b/api/interfaces/components_Pagination.PaginationClasses.md
@@ -24,7 +24,7 @@ The class for each of the pagination button.
 
 #### Defined in
 
-[components/Pagination.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L26)
+[components/Pagination.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L26)
 
 ___
 
@@ -36,4 +36,4 @@ The class for the pagination button group.
 
 #### Defined in
 
-[components/Pagination.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L28)
+[components/Pagination.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L28)

--- a/api/interfaces/components_Pagination.PaginationLabels.md
+++ b/api/interfaces/components_Pagination.PaginationLabels.md
@@ -25,7 +25,7 @@ The "First" button label. Defaults to "First".
 
 #### Defined in
 
-[components/Pagination.tsx:11](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L11)
+[components/Pagination.tsx:11](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L11)
 
 ___
 
@@ -37,7 +37,7 @@ The "Last" button label. Defaults to "Last".
 
 #### Defined in
 
-[components/Pagination.tsx:13](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L13)
+[components/Pagination.tsx:13](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L13)
 
 ___
 
@@ -49,7 +49,7 @@ The "Next" button label. Defaults to "Next".
 
 #### Defined in
 
-[components/Pagination.tsx:17](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L17)
+[components/Pagination.tsx:17](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L17)
 
 ___
 
@@ -61,4 +61,4 @@ The "Prev" button label. Defaults to "Prev".
 
 #### Defined in
 
-[components/Pagination.tsx:15](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L15)
+[components/Pagination.tsx:15](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L15)

--- a/api/interfaces/components_Pagination.PaginationLabels.md
+++ b/api/interfaces/components_Pagination.PaginationLabels.md
@@ -25,7 +25,7 @@ The "First" button label. Defaults to "First".
 
 #### Defined in
 
-[components/Pagination.tsx:11](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L11)
+[components/Pagination.tsx:11](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L11)
 
 ___
 
@@ -37,7 +37,7 @@ The "Last" button label. Defaults to "Last".
 
 #### Defined in
 
-[components/Pagination.tsx:13](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L13)
+[components/Pagination.tsx:13](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L13)
 
 ___
 
@@ -49,7 +49,7 @@ The "Next" button label. Defaults to "Next".
 
 #### Defined in
 
-[components/Pagination.tsx:17](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L17)
+[components/Pagination.tsx:17](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L17)
 
 ___
 
@@ -61,4 +61,4 @@ The "Prev" button label. Defaults to "Prev".
 
 #### Defined in
 
-[components/Pagination.tsx:15](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L15)
+[components/Pagination.tsx:15](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L15)

--- a/api/interfaces/components_Pagination.PaginationProps.md
+++ b/api/interfaces/components_Pagination.PaginationProps.md
@@ -28,7 +28,7 @@ To prevent layout shifts, `visibility: hidden` will be applied instead of
 
 #### Defined in
 
-[components/Pagination.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L45)
+[components/Pagination.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L45)
 
 ___
 
@@ -40,7 +40,7 @@ Customize the classes of the `Pagination` component.
 
 #### Defined in
 
-[components/Pagination.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L38)
+[components/Pagination.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L38)
 
 ___
 
@@ -60,7 +60,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/Pagination.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L47)
+[components/Pagination.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L47)
 
 ___
 
@@ -72,4 +72,4 @@ Customize the labels of the `Pagination` component.
 
 #### Defined in
 
-[components/Pagination.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L36)
+[components/Pagination.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L36)

--- a/api/interfaces/components_Pagination.PaginationProps.md
+++ b/api/interfaces/components_Pagination.PaginationProps.md
@@ -28,7 +28,7 @@ To prevent layout shifts, `visibility: hidden` will be applied instead of
 
 #### Defined in
 
-[components/Pagination.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L45)
+[components/Pagination.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L45)
 
 ___
 
@@ -40,7 +40,7 @@ Customize the classes of the `Pagination` component.
 
 #### Defined in
 
-[components/Pagination.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L38)
+[components/Pagination.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L38)
 
 ___
 
@@ -60,7 +60,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/Pagination.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L47)
+[components/Pagination.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L47)
 
 ___
 
@@ -72,4 +72,4 @@ Customize the labels of the `Pagination` component.
 
 #### Defined in
 
-[components/Pagination.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L36)
+[components/Pagination.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L36)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsClasses.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsClasses.md
@@ -25,7 +25,7 @@ The class for the select input.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L36)
+[components/PaginationOptions.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L36)
 
 ___
 
@@ -38,7 +38,7 @@ the `beforeSelect` label, the select input, and the `afterSelect` text.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L32)
+[components/PaginationOptions.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L32)
 
 ___
 
@@ -50,4 +50,4 @@ The class for the `beforeSelect` and `afterSelect` labels.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L34)
+[components/PaginationOptions.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L34)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsClasses.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsClasses.md
@@ -25,7 +25,7 @@ The class for the select input.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L36)
+[components/PaginationOptions.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L36)
 
 ___
 
@@ -38,7 +38,7 @@ the `beforeSelect` label, the select input, and the `afterSelect` text.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L32)
+[components/PaginationOptions.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L32)
 
 ___
 
@@ -50,4 +50,4 @@ The class for the `beforeSelect` and `afterSelect` labels.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L34)
+[components/PaginationOptions.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L34)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsLabels.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsLabels.md
@@ -25,7 +25,7 @@ is a horizontal form instead of vertical (e.g. using `flex-direction: row`).
 
 #### Defined in
 
-[components/PaginationOptions.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L20)
+[components/PaginationOptions.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L20)
 
 ___
 
@@ -38,4 +38,4 @@ Defaults to "Rows per page".
 
 #### Defined in
 
-[components/PaginationOptions.tsx:14](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L14)
+[components/PaginationOptions.tsx:14](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L14)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsLabels.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsLabels.md
@@ -25,7 +25,7 @@ is a horizontal form instead of vertical (e.g. using `flex-direction: row`).
 
 #### Defined in
 
-[components/PaginationOptions.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L20)
+[components/PaginationOptions.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L20)
 
 ___
 
@@ -38,4 +38,4 @@ Defaults to "Rows per page".
 
 #### Defined in
 
-[components/PaginationOptions.tsx:14](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L14)
+[components/PaginationOptions.tsx:14](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L14)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsProps.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsProps.md
@@ -28,7 +28,7 @@ To prevent layout shifts, `visibility: hidden` will be applied instead of
 
 #### Defined in
 
-[components/PaginationOptions.tsx:53](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L53)
+[components/PaginationOptions.tsx:53](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L53)
 
 ___
 
@@ -40,7 +40,7 @@ Customize the classes of the `PaginationOptions` component.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L46)
+[components/PaginationOptions.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L46)
 
 ___
 
@@ -61,7 +61,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:55](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L55)
+[components/PaginationOptions.tsx:55](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L55)
 
 ___
 
@@ -73,4 +73,4 @@ Customize the labels of the `PaginationOptions` component.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L44)
+[components/PaginationOptions.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L44)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsProps.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsProps.md
@@ -28,7 +28,7 @@ To prevent layout shifts, `visibility: hidden` will be applied instead of
 
 #### Defined in
 
-[components/PaginationOptions.tsx:53](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L53)
+[components/PaginationOptions.tsx:53](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L53)
 
 ___
 
@@ -40,7 +40,7 @@ Customize the classes of the `PaginationOptions` component.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L46)
+[components/PaginationOptions.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L46)
 
 ___
 
@@ -61,7 +61,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:55](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L55)
+[components/PaginationOptions.tsx:55](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L55)
 
 ___
 
@@ -73,4 +73,4 @@ Customize the labels of the `PaginationOptions` component.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L44)
+[components/PaginationOptions.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L44)

--- a/api/interfaces/components_TableBody.TableBodyClasses.md
+++ b/api/interfaces/components_TableBody.TableBodyClasses.md
@@ -25,7 +25,7 @@ The class for the `tbody` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L28)
+[components/TableBody.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableBody.tsx#L28)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the `td` tags inside each `tr` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L32)
+[components/TableBody.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableBody.tsx#L32)
 
 ___
 
@@ -49,4 +49,4 @@ The class for the `tr` tags inside `tbody`.
 
 #### Defined in
 
-[components/TableBody.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L30)
+[components/TableBody.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableBody.tsx#L30)

--- a/api/interfaces/components_TableBody.TableBodyClasses.md
+++ b/api/interfaces/components_TableBody.TableBodyClasses.md
@@ -25,7 +25,7 @@ The class for the `tbody` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableBody.tsx#L28)
+[components/TableBody.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L28)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the `td` tags inside each `tr` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableBody.tsx#L32)
+[components/TableBody.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L32)
 
 ___
 
@@ -49,4 +49,4 @@ The class for the `tr` tags inside `tbody`.
 
 #### Defined in
 
-[components/TableBody.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableBody.tsx#L30)
+[components/TableBody.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L30)

--- a/api/interfaces/components_TableBody.TableBodyLabels.md
+++ b/api/interfaces/components_TableBody.TableBodyLabels.md
@@ -23,4 +23,4 @@ no data (empty array), or no matching found for the filtered text.
 
 #### Defined in
 
-[components/TableBody.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableBody.tsx#L19)
+[components/TableBody.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L19)

--- a/api/interfaces/components_TableBody.TableBodyLabels.md
+++ b/api/interfaces/components_TableBody.TableBodyLabels.md
@@ -23,4 +23,4 @@ no data (empty array), or no matching found for the filtered text.
 
 #### Defined in
 
-[components/TableBody.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L19)
+[components/TableBody.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableBody.tsx#L19)

--- a/api/interfaces/components_TableBody.TableBodyProps.md
+++ b/api/interfaces/components_TableBody.TableBodyProps.md
@@ -34,7 +34,7 @@ Customize the classes of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:42](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableBody.tsx#L42)
+[components/TableBody.tsx:42](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L42)
 
 ___
 
@@ -54,7 +54,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/TableBody.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableBody.tsx#L46)
+[components/TableBody.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L46)
 
 ___
 
@@ -66,7 +66,7 @@ Customize the labels of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:40](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableBody.tsx#L40)
+[components/TableBody.tsx:40](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L40)
 
 ## Methods
 
@@ -88,4 +88,4 @@ The function fired when any of the rows is clicked.
 
 #### Defined in
 
-[components/TableBody.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableBody.tsx#L44)
+[components/TableBody.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L44)

--- a/api/interfaces/components_TableBody.TableBodyProps.md
+++ b/api/interfaces/components_TableBody.TableBodyProps.md
@@ -34,7 +34,7 @@ Customize the classes of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:42](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L42)
+[components/TableBody.tsx:42](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableBody.tsx#L42)
 
 ___
 
@@ -54,7 +54,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/TableBody.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L46)
+[components/TableBody.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableBody.tsx#L46)
 
 ___
 
@@ -66,7 +66,7 @@ Customize the labels of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:40](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L40)
+[components/TableBody.tsx:40](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableBody.tsx#L40)
 
 ## Methods
 
@@ -88,4 +88,4 @@ The function fired when any of the rows is clicked.
 
 #### Defined in
 
-[components/TableBody.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L44)
+[components/TableBody.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableBody.tsx#L44)

--- a/api/interfaces/components_TableHeader.TableHeaderClasses.md
+++ b/api/interfaces/components_TableHeader.TableHeaderClasses.md
@@ -25,7 +25,7 @@ The class for the `th` tags inside each `tr` tag.
 
 #### Defined in
 
-[components/TableHeader.tsx:29](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableHeader.tsx#L29)
+[components/TableHeader.tsx:29](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L29)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the `thead` tag.
 
 #### Defined in
 
-[components/TableHeader.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableHeader.tsx#L25)
+[components/TableHeader.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L25)
 
 ___
 
@@ -49,4 +49,4 @@ The class for the `tr` tags inside `tbody`.
 
 #### Defined in
 
-[components/TableHeader.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableHeader.tsx#L27)
+[components/TableHeader.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L27)

--- a/api/interfaces/components_TableHeader.TableHeaderClasses.md
+++ b/api/interfaces/components_TableHeader.TableHeaderClasses.md
@@ -25,7 +25,7 @@ The class for the `th` tags inside each `tr` tag.
 
 #### Defined in
 
-[components/TableHeader.tsx:29](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L29)
+[components/TableHeader.tsx:29](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableHeader.tsx#L29)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the `thead` tag.
 
 #### Defined in
 
-[components/TableHeader.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L25)
+[components/TableHeader.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableHeader.tsx#L25)
 
 ___
 
@@ -49,4 +49,4 @@ The class for the `tr` tags inside `tbody`.
 
 #### Defined in
 
-[components/TableHeader.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L27)
+[components/TableHeader.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableHeader.tsx#L27)

--- a/api/interfaces/components_TableHeader.TableHeaderProps.md
+++ b/api/interfaces/components_TableHeader.TableHeaderProps.md
@@ -23,7 +23,7 @@ Customize the classes of the `TableHeader` component.
 
 #### Defined in
 
-[components/TableHeader.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L37)
+[components/TableHeader.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableHeader.tsx#L37)
 
 ___
 
@@ -45,4 +45,4 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/TableHeader.tsx:39](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L39)
+[components/TableHeader.tsx:39](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableHeader.tsx#L39)

--- a/api/interfaces/components_TableHeader.TableHeaderProps.md
+++ b/api/interfaces/components_TableHeader.TableHeaderProps.md
@@ -23,7 +23,7 @@ Customize the classes of the `TableHeader` component.
 
 #### Defined in
 
-[components/TableHeader.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableHeader.tsx#L37)
+[components/TableHeader.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L37)
 
 ___
 
@@ -45,4 +45,4 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/TableHeader.tsx:39](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableHeader.tsx#L39)
+[components/TableHeader.tsx:39](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L39)

--- a/api/interfaces/helpers_types.CheckboxState.md
+++ b/api/interfaces/helpers_types.CheckboxState.md
@@ -25,7 +25,7 @@ the behavior of the `Set` type.
 
 #### Defined in
 
-[helpers/types.ts:25](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L25)
+[helpers/types.ts:25](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L25)
 
 ___
 
@@ -38,4 +38,4 @@ The checkbox states. This is useful to determine the "Select all" and
 
 #### Defined in
 
-[helpers/types.ts:30](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L30)
+[helpers/types.ts:30](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L30)

--- a/api/interfaces/helpers_types.CheckboxState.md
+++ b/api/interfaces/helpers_types.CheckboxState.md
@@ -25,7 +25,7 @@ the behavior of the `Set` type.
 
 #### Defined in
 
-[helpers/types.ts:25](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L25)
+[helpers/types.ts:25](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L25)
 
 ___
 
@@ -38,4 +38,4 @@ The checkbox states. This is useful to determine the "Select all" and
 
 #### Defined in
 
-[helpers/types.ts:30](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L30)
+[helpers/types.ts:30](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L30)

--- a/api/interfaces/helpers_types.SortType.md
+++ b/api/interfaces/helpers_types.SortType.md
@@ -23,7 +23,7 @@ The sort order.
 
 #### Defined in
 
-[helpers/types.ts:13](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L13)
+[helpers/types.ts:13](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L13)
 
 ___
 
@@ -36,4 +36,4 @@ This is the same as `header.prop` from `TableColumnType` interface.
 
 #### Defined in
 
-[helpers/types.ts:11](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L11)
+[helpers/types.ts:11](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L11)

--- a/api/interfaces/helpers_types.SortType.md
+++ b/api/interfaces/helpers_types.SortType.md
@@ -23,7 +23,7 @@ The sort order.
 
 #### Defined in
 
-[helpers/types.ts:13](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L13)
+[helpers/types.ts:13](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L13)
 
 ___
 
@@ -36,4 +36,4 @@ This is the same as `header.prop` from `TableColumnType` interface.
 
 #### Defined in
 
-[helpers/types.ts:11](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L11)
+[helpers/types.ts:11](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L11)

--- a/api/interfaces/helpers_types.TableColumnType.md
+++ b/api/interfaces/helpers_types.TableColumnType.md
@@ -48,7 +48,7 @@ the same thing.
 
 #### Defined in
 
-[helpers/types.ts:90](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L90)
+[helpers/types.ts:90](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L90)
 
 ___
 
@@ -67,7 +67,7 @@ The props passed to the table columns under `tbody`.
 
 #### Defined in
 
-[helpers/types.ts:53](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L53)
+[helpers/types.ts:53](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L53)
 
 ___
 
@@ -87,7 +87,7 @@ the column will be a checkbox, both the headers and the rest of the rows.
 
 #### Defined in
 
-[helpers/types.ts:79](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L79)
+[helpers/types.ts:79](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L79)
 
 ___
 
@@ -101,7 +101,7 @@ will not be rendered.
 
 #### Defined in
 
-[helpers/types.ts:70](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L70)
+[helpers/types.ts:70](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L70)
 
 ___
 
@@ -113,7 +113,7 @@ Determines whether the column is sortable or not.
 
 #### Defined in
 
-[helpers/types.ts:74](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L74)
+[helpers/types.ts:74](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L74)
 
 ___
 
@@ -127,7 +127,7 @@ have unique `prop` field.
 
 #### Defined in
 
-[helpers/types.ts:43](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L43)
+[helpers/types.ts:43](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L43)
 
 ___
 
@@ -139,7 +139,7 @@ The title for the header.
 
 #### Defined in
 
-[helpers/types.ts:45](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L45)
+[helpers/types.ts:45](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L45)
 
 ## Methods
 
@@ -161,7 +161,7 @@ Custom render the table body cell. This is a function with the row data as param
 
 #### Defined in
 
-[helpers/types.ts:51](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L51)
+[helpers/types.ts:51](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L51)
 
 ___
 
@@ -184,4 +184,4 @@ Custom render the table header cell.
 
 #### Defined in
 
-[helpers/types.ts:47](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L47)
+[helpers/types.ts:47](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L47)

--- a/api/interfaces/helpers_types.TableColumnType.md
+++ b/api/interfaces/helpers_types.TableColumnType.md
@@ -48,7 +48,7 @@ the same thing.
 
 #### Defined in
 
-[helpers/types.ts:90](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L90)
+[helpers/types.ts:90](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L90)
 
 ___
 
@@ -67,7 +67,7 @@ The props passed to the table columns under `tbody`.
 
 #### Defined in
 
-[helpers/types.ts:53](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L53)
+[helpers/types.ts:53](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L53)
 
 ___
 
@@ -87,7 +87,7 @@ the column will be a checkbox, both the headers and the rest of the rows.
 
 #### Defined in
 
-[helpers/types.ts:79](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L79)
+[helpers/types.ts:79](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L79)
 
 ___
 
@@ -101,7 +101,7 @@ will not be rendered.
 
 #### Defined in
 
-[helpers/types.ts:70](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L70)
+[helpers/types.ts:70](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L70)
 
 ___
 
@@ -113,7 +113,7 @@ Determines whether the column is sortable or not.
 
 #### Defined in
 
-[helpers/types.ts:74](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L74)
+[helpers/types.ts:74](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L74)
 
 ___
 
@@ -127,7 +127,7 @@ have unique `prop` field.
 
 #### Defined in
 
-[helpers/types.ts:43](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L43)
+[helpers/types.ts:43](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L43)
 
 ___
 
@@ -139,7 +139,7 @@ The title for the header.
 
 #### Defined in
 
-[helpers/types.ts:45](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L45)
+[helpers/types.ts:45](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L45)
 
 ## Methods
 
@@ -161,7 +161,7 @@ Custom render the table body cell. This is a function with the row data as param
 
 #### Defined in
 
-[helpers/types.ts:51](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L51)
+[helpers/types.ts:51](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L51)
 
 ___
 
@@ -184,4 +184,4 @@ Custom render the table header cell.
 
 #### Defined in
 
-[helpers/types.ts:47](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L47)
+[helpers/types.ts:47](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L47)

--- a/api/modules/components_BulkCheckboxControl.md
+++ b/api/modules/components_BulkCheckboxControl.md
@@ -38,4 +38,4 @@ change to "Deselect all" button.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/BulkCheckboxControl.tsx#L52)
+[components/BulkCheckboxControl.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/BulkCheckboxControl.tsx#L52)

--- a/api/modules/components_BulkCheckboxControl.md
+++ b/api/modules/components_BulkCheckboxControl.md
@@ -38,4 +38,4 @@ change to "Deselect all" button.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/BulkCheckboxControl.tsx#L52)
+[components/BulkCheckboxControl.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/BulkCheckboxControl.tsx#L52)

--- a/api/modules/components_DatatableWrapper.md
+++ b/api/modules/components_DatatableWrapper.md
@@ -42,4 +42,4 @@
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:219](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L219)
+[components/DatatableWrapper.tsx:225](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/DatatableWrapper.tsx#L225)

--- a/api/modules/components_DatatableWrapper.md
+++ b/api/modules/components_DatatableWrapper.md
@@ -42,4 +42,4 @@
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:219](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/DatatableWrapper.tsx#L219)
+[components/DatatableWrapper.tsx:219](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/DatatableWrapper.tsx#L219)

--- a/api/modules/components_Filter.md
+++ b/api/modules/components_Filter.md
@@ -35,4 +35,4 @@ prop. Otherwise, this component will return `null`.
 
 #### Defined in
 
-[components/Filter.tsx:48](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Filter.tsx#L48)
+[components/Filter.tsx:48](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L48)

--- a/api/modules/components_Filter.md
+++ b/api/modules/components_Filter.md
@@ -35,4 +35,4 @@ prop. Otherwise, this component will return `null`.
 
 #### Defined in
 
-[components/Filter.tsx:48](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Filter.tsx#L48)
+[components/Filter.tsx:48](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Filter.tsx#L48)

--- a/api/modules/components_Pagination.md
+++ b/api/modules/components_Pagination.md
@@ -41,4 +41,4 @@ When `alwaysShowPagination` is set to `false`, then this component will be visua
 
 #### Defined in
 
-[components/Pagination.tsx:71](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L71)
+[components/Pagination.tsx:71](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/Pagination.tsx#L71)

--- a/api/modules/components_Pagination.md
+++ b/api/modules/components_Pagination.md
@@ -41,4 +41,4 @@ When `alwaysShowPagination` is set to `false`, then this component will be visua
 
 #### Defined in
 
-[components/Pagination.tsx:71](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/Pagination.tsx#L71)
+[components/Pagination.tsx:71](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/Pagination.tsx#L71)

--- a/api/modules/components_PaginationOptions.md
+++ b/api/modules/components_PaginationOptions.md
@@ -42,4 +42,4 @@ When `alwaysShowPagination` is set to `false`, then this component will be visua
 
 #### Defined in
 
-[components/PaginationOptions.tsx:81](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/PaginationOptions.tsx#L81)
+[components/PaginationOptions.tsx:81](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L81)

--- a/api/modules/components_PaginationOptions.md
+++ b/api/modules/components_PaginationOptions.md
@@ -42,4 +42,4 @@ When `alwaysShowPagination` is set to `false`, then this component will be visua
 
 #### Defined in
 
-[components/PaginationOptions.tsx:81](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/PaginationOptions.tsx#L81)
+[components/PaginationOptions.tsx:81](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/PaginationOptions.tsx#L81)

--- a/api/modules/components_TableBody.md
+++ b/api/modules/components_TableBody.md
@@ -41,4 +41,4 @@ such as `tr` and `td` tags.
 
 #### Defined in
 
-[components/TableBody.tsx:66](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableBody.tsx#L66)
+[components/TableBody.tsx:66](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L66)

--- a/api/modules/components_TableBody.md
+++ b/api/modules/components_TableBody.md
@@ -41,4 +41,4 @@ such as `tr` and `td` tags.
 
 #### Defined in
 
-[components/TableBody.tsx:66](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableBody.tsx#L66)
+[components/TableBody.tsx:66](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableBody.tsx#L66)

--- a/api/modules/components_TableHeader.md
+++ b/api/modules/components_TableHeader.md
@@ -33,4 +33,4 @@ Renders a list of table headers.
 
 #### Defined in
 
-[components/TableHeader.tsx:62](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/components/TableHeader.tsx#L62)
+[components/TableHeader.tsx:62](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L62)

--- a/api/modules/components_TableHeader.md
+++ b/api/modules/components_TableHeader.md
@@ -33,4 +33,4 @@ Renders a list of table headers.
 
 #### Defined in
 
-[components/TableHeader.tsx:62](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/components/TableHeader.tsx#L62)
+[components/TableHeader.tsx:62](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/components/TableHeader.tsx#L62)

--- a/api/modules/helpers_types.md
+++ b/api/modules/helpers_types.md
@@ -49,7 +49,7 @@ The helper type for the checkbox change eveent.
 
 #### Defined in
 
-[helpers/types.ts:144](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L144)
+[helpers/types.ts:144](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L144)
 
 ___
 
@@ -73,7 +73,7 @@ can make the sort result incorrect, e.g. sorting formatted dates.
 
 #### Defined in
 
-[helpers/types.ts:105](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L105)
+[helpers/types.ts:105](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L105)
 
 ___
 
@@ -99,7 +99,7 @@ The helper type for the filter change event.
 
 #### Defined in
 
-[helpers/types.ts:119](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L119)
+[helpers/types.ts:119](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L119)
 
 ___
 
@@ -125,7 +125,7 @@ The helper type for the sort by prop change event.
 
 #### Defined in
 
-[helpers/types.ts:134](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L134)
+[helpers/types.ts:134](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L134)
 
 ___
 
@@ -151,7 +151,7 @@ The helper type for the rows per page change event.
 
 #### Defined in
 
-[helpers/types.ts:139](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L139)
+[helpers/types.ts:139](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L139)
 
 ___
 
@@ -177,7 +177,7 @@ The helper type for the sort by prop change event.
 
 #### Defined in
 
-[helpers/types.ts:129](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L129)
+[helpers/types.ts:129](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L129)
 
 ___
 
@@ -203,7 +203,7 @@ The helper type for the sort by next prop change event.
 
 #### Defined in
 
-[helpers/types.ts:124](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L124)
+[helpers/types.ts:124](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L124)
 
 ___
 
@@ -221,4 +221,4 @@ This is used for the `extend` keyword in the components.
 
 #### Defined in
 
-[helpers/types.ts:112](https://github.com/imballinst/react-bs-datatable/blob/f45e78e/src/helpers/types.ts#L112)
+[helpers/types.ts:112](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L112)

--- a/api/modules/helpers_types.md
+++ b/api/modules/helpers_types.md
@@ -49,7 +49,7 @@ The helper type for the checkbox change eveent.
 
 #### Defined in
 
-[helpers/types.ts:144](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L144)
+[helpers/types.ts:144](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L144)
 
 ___
 
@@ -73,7 +73,7 @@ can make the sort result incorrect, e.g. sorting formatted dates.
 
 #### Defined in
 
-[helpers/types.ts:105](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L105)
+[helpers/types.ts:105](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L105)
 
 ___
 
@@ -99,7 +99,7 @@ The helper type for the filter change event.
 
 #### Defined in
 
-[helpers/types.ts:119](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L119)
+[helpers/types.ts:119](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L119)
 
 ___
 
@@ -125,7 +125,7 @@ The helper type for the sort by prop change event.
 
 #### Defined in
 
-[helpers/types.ts:134](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L134)
+[helpers/types.ts:134](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L134)
 
 ___
 
@@ -151,7 +151,7 @@ The helper type for the rows per page change event.
 
 #### Defined in
 
-[helpers/types.ts:139](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L139)
+[helpers/types.ts:139](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L139)
 
 ___
 
@@ -177,7 +177,7 @@ The helper type for the sort by prop change event.
 
 #### Defined in
 
-[helpers/types.ts:129](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L129)
+[helpers/types.ts:129](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L129)
 
 ___
 
@@ -203,7 +203,7 @@ The helper type for the sort by next prop change event.
 
 #### Defined in
 
-[helpers/types.ts:124](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L124)
+[helpers/types.ts:124](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L124)
 
 ___
 
@@ -221,4 +221,4 @@ This is used for the `extend` keyword in the components.
 
 #### Defined in
 
-[helpers/types.ts:112](https://github.com/imballinst/react-bs-datatable/blob/4be4269/src/helpers/types.ts#L112)
+[helpers/types.ts:112](https://github.com/imballinst/react-bs-datatable/blob/e49652b/src/helpers/types.ts#L112)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bs-datatable",
-  "version": "3.1.1-alpha.0",
+  "version": "3.1.1-alpha.1",
   "description": "React Bootstrap Datatable (without jQuery) with sorting, filter, and pagination",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bs-datatable",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "description": "React Bootstrap Datatable (without jQuery) with sorting, filter, and pagination",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/__stories__/00-Uncontrolled.stories.tsx
+++ b/src/__stories__/00-Uncontrolled.stories.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, useRef } from 'react';
+import React, { MutableRefObject, ReactNode, useRef } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Col, Row, Table } from 'react-bootstrap';
 import { parse } from 'date-fns';
@@ -11,7 +11,8 @@ import { TableBody, TableBodyProps } from '../components/TableBody';
 import {
   DatatableWrapper,
   DatatableWrapperProps,
-  UncontrolledTableEvents
+  UncontrolledTableEvents,
+  useDatatableWrapper
 } from '../components/DatatableWrapper';
 import { Filter } from '../components/Filter';
 import { PaginationOptions } from '../components/PaginationOptions';
@@ -145,6 +146,45 @@ RowOnClick.argTypes = {
   }
 };
 
+const RaisedTableContextTemplate: ComponentStory<typeof StoryTable> = (
+  args
+) => {
+  function Children() {
+    const { onSortByPropChange, sortState } = useDatatableWrapper();
+
+    return (
+      <div>
+        <label>Sort state</label>
+        <pre>{JSON.stringify(sortState)}</pre>
+
+        <button onClick={() => onSortByPropChange('name')}>
+          External sort by name
+        </button>
+        <button onClick={() => onSortByPropChange('username')}>
+          External sort by username
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <StoryTable {...args}>
+      <Children />
+    </StoryTable>
+  );
+};
+
+export const RaisedTableContext = RaisedTableContextTemplate.bind({});
+RaisedTableContext.storyName =
+  'Uncontrolled table with external sort events trigger';
+RaisedTableContext.args = {
+  sortableFields: ['Name', 'Username', 'Last Update', 'Score'],
+  filterableFields: ['Name', 'Username', 'Location'],
+  alwaysShowPagination: true,
+  rowsPerPage: 10,
+  rowsPerPageOptions: [5, 10, 15, 20]
+};
+
 const RefTemplate: ComponentStory<typeof StoryTable> = (args) => {
   const tableEventsRef = useRef<UncontrolledTableEvents>();
   return (
@@ -166,7 +206,7 @@ const RefTemplate: ComponentStory<typeof StoryTable> = (args) => {
 
 export const UncontrolledWithRefEvents = RefTemplate.bind({});
 UncontrolledWithRefEvents.storyName =
-  'Uncontrolled table with external sort events trigger';
+  'Uncontrolled table with external sort events trigger (deprecated)';
 UncontrolledWithRefEvents.args = {
   sortableFields: ['Name', 'Username', 'Last Update', 'Score'],
   filterableFields: ['Name', 'Username', 'Location'],
@@ -202,7 +242,8 @@ function StoryTable({
   // For on click row event.
   rowOnClickText,
   rowOnClickFn,
-  tableEventsRef
+  tableEventsRef,
+  children
 }: {
   sortableFields?: string[];
   filterableFields?: string[];
@@ -226,6 +267,7 @@ function StoryTable({
   // Set this to `true` if we want to control the table events from outside,
   // but keep the table uncontrolled.
   tableEventsRef?: MutableRefObject<UncontrolledTableEvents | undefined>;
+  children?: ReactNode;
 }) {
   const headers: TableColumnType<StoryColumnType>[] = STORY_HEADERS.map(
     (header) => ({
@@ -285,6 +327,7 @@ function StoryTable({
         }
       }}
     >
+      {children}
       <Row className="mb-4">
         <Col
           xs={12}

--- a/src/__stories__/00-Uncontrolled.test.tsx
+++ b/src/__stories__/00-Uncontrolled.test.tsx
@@ -6,7 +6,8 @@ import {
   CustomLabels,
   CustomCellRender,
   RowOnClick,
-  UncontrolledWithRefEvents
+  UncontrolledWithRefEvents,
+  RaisedTableContext
 } from './00-Uncontrolled.stories';
 import { UncontrolledTableEvents } from '../components/DatatableWrapper';
 
@@ -322,6 +323,42 @@ describe('Trigger events from outside: sort', () => {
   };
 
   test('sort name and username using external buttons', () => {
+    const { getByText, getByRole } = render(
+      <RaisedTableContext {...DEFAULT_PROPS} />
+    );
+
+    let tableElement = getByRole('table');
+    // We are doing the same sort scenario like the normal use case,
+    // but we are doing it using the refs instead.
+    // Sort descending the first column (since it's the initial state).
+    let externalSortNameBtn = getByText('External sort by name', {
+      selector: 'button'
+    });
+    let nameTh = getByText('Name', { selector: 'th' });
+    fireEvent.click(externalSortNameBtn);
+
+    let tableRows = tableElement.querySelector('tbody')?.querySelectorAll('tr');
+    expect(tableRows).toBeDefined();
+    expect(tableRows?.[0].querySelector('td')?.textContent).toBe('Wileen');
+    expect(nameTh.getAttribute('data-sort-order')).toBe('desc');
+
+    // Try sorting the other columns.
+    let externalSortUsernameBtn = getByText('External sort by username', {
+      selector: 'button'
+    });
+    let usernameTh = getByText('Username', { selector: 'th' });
+    fireEvent.click(externalSortUsernameBtn);
+
+    // The clicked header should have its sort state.
+    tableRows = tableElement.querySelector('tbody')?.querySelectorAll('tr');
+    expect(tableRows).toBeDefined();
+    expect(tableRows?.[0].querySelector('td')?.textContent).toBe('Aaren');
+    expect(usernameTh.getAttribute('data-sort-order')).toBe('asc');
+    // Meanwhile, the "Name" header should reset to its default state.
+    expect(nameTh.getAttribute('data-sort-order')).toBe(null);
+  });
+
+  test('sort name and username using external buttons (deprecated)', () => {
     const { getByText, getByRole } = render(
       <UncontrolledWithRefEvents {...DEFAULT_PROPS} />
     );

--- a/src/components/DatatableWrapper.tsx
+++ b/src/components/DatatableWrapper.tsx
@@ -183,6 +183,12 @@ export interface DatatableWrapperProps<TTableRowType> {
   paginationProps?: TablePaginationParameters;
   paginationOptionsProps?: TablePaginationOptionsParameters;
   checkboxProps?: TableCheckboxParameters;
+  /**
+   * @deprecated
+   *
+   * Usage of `tableEventsRef` is deprecated. Consider using `useDatatableWrapper`
+   * and raising the `DatatableWrapper` a bit higher in the structure instead.
+   */
   tableEventsRef?: MutableRefObject<UncontrolledTableEvents | undefined>;
 }
 
@@ -253,6 +259,15 @@ export function DatatableWrapper<TTableRowType = any>({
     headers,
     initialStates: checkboxProps?.initialState
   });
+
+  useEffect(() => {
+    if (tableEventsRef !== undefined) {
+      console.warn(
+        'Warning: Usage of `tableEventsRef` is deprecated. Consider using `useDatatableWrapper`' +
+          'and raising the `DatatableWrapper` a bit higher in the structure instead.'
+      );
+    }
+  }, [tableEventsRef]);
 
   useEffect(() => {
     // Resets the table if the headers passed down is different.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-export { DatatableWrapper } from './components/DatatableWrapper';
+export {
+  DatatableWrapper,
+  useDatatableWrapper
+} from './components/DatatableWrapper';
 export type { DatatableWrapperProps } from './components/DatatableWrapper';
 
 export { Filter } from './components/Filter';


### PR DESCRIPTION
This PR is related to https://github.com/imballinst/react-bs-datatable/pull/127, where we perhaps require the table data. We can put our `DatatableWrapper` far in the JSX structure and as such, we can take advantage of the context's value.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>