### PR TITLE
fix: fix initial sort porder is not assigned to default sort

### DIFF
--- a/src/__stories__/00-Uncontrolled.stories.tsx
+++ b/src/__stories__/00-Uncontrolled.stories.tsx
@@ -258,7 +258,9 @@ function StoryTable({
   rowOnClickText,
   rowOnClickFn,
   tableEventsRef,
-  children
+  children,
+  // Additional sort props.
+  sortProps = {}
 }: {
   sortableFields?: string[];
   filterableFields?: string[];
@@ -285,6 +287,8 @@ function StoryTable({
   // but keep the table uncontrolled.
   tableEventsRef?: MutableRefObject<UncontrolledTableEvents | undefined>;
   children?: ReactNode;
+  // Additional sort props.
+  sortProps?: DatatableWrapperProps<StoryColumnType>['sortProps'];
 }) {
   const headers: TableColumnType<StoryColumnType>[] = STORY_HEADERS.map(
     (header) => ({
@@ -335,7 +339,10 @@ function StoryTable({
     <DatatableWrapper
       body={json}
       headers={headers}
-      sortProps={SORT_PROPS}
+      sortProps={{
+        ...SORT_PROPS,
+        ...sortProps
+      }}
       tableEventsRef={tableEventsRef}
       paginationOptionsProps={{
         initialState: {

--- a/src/__stories__/00-Uncontrolled.test.tsx
+++ b/src/__stories__/00-Uncontrolled.test.tsx
@@ -20,6 +20,33 @@ describe('Filter, sort, pagination', () => {
     rowsPerPageOptions: [8, 16, 24, 32]
   };
 
+  describe('initial states', () => {
+    test('initial sort', () => {
+      const { getByRole } = render(
+        <FilterSortPagination
+          {...DEFAULT_PROPS}
+          sortProps={{
+            initialState: {
+              prop: 'score',
+              order: 'desc'
+            }
+          }}
+        />
+      );
+
+      let tableElement = getByRole('table');
+
+      expect(
+        tableElement
+          .querySelector('tbody')
+          ?.querySelectorAll('tr')
+          .item(0)
+          .querySelectorAll('td')
+          .item(0).innerHTML
+      ).toBe('Suzette');
+    });
+  });
+
   test('normal use case', () => {
     const {
       getByText,

--- a/src/components/DatatableWrapper.tsx
+++ b/src/components/DatatableWrapper.tsx
@@ -474,7 +474,10 @@ function getDefaultDatatableState<TTableRowType = TableRowType>({
   | 'checkboxProps'
   | 'headers'
 >): DatatableState {
-  const defaultSort: SortType = { order: 'asc', prop: '' };
+  const defaultSort: SortType = sortProps?.initialState || {
+    order: 'asc',
+    prop: ''
+  };
   const checkbox: Record<string, CheckboxState> =
     checkboxProps?.initialState || {};
   let isFilterable = filterProps !== undefined;
@@ -482,14 +485,9 @@ function getDefaultDatatableState<TTableRowType = TableRowType>({
   for (const header of headers) {
     const prop = header.prop.toString();
 
-    // Set the default sort header.
-    if (
+    if (defaultSort.prop === '' && header.isSortable) {
       // If the sorted prop is still "empty", then we assign it with the current header.
-      (defaultSort.prop === '' && header.isSortable) ||
-      // Or, if the header prop matches the initial state, then set it as well.
-      prop === sortProps?.initialState?.prop
-    ) {
-      defaultSort.prop = prop;
+      defaultSort.prop = String(header.prop);
     }
 
     // Set the default checkbox values, if not provided from `checkboxProps`.


### PR DESCRIPTION
Addresses https://github.com/imballinst/react-bs-datatable/issues/134. Will create an alpha version and test in the sandbox first before releasing a patch version. I will also backport this to previous versions.