### PR TITLE
feat: implement thProps in column definition 

### DIFF
--- a/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlClasses.md
+++ b/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlClasses.md
@@ -24,4 +24,4 @@ This defaults to `link-primary text-decoration-none`.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/BulkCheckboxControl.tsx#L18)
+[components/BulkCheckboxControl.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/BulkCheckboxControl.tsx#L18)

--- a/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlProps.md
+++ b/api/interfaces/components_BulkCheckboxControl.BulkCheckboxControlProps.md
@@ -23,7 +23,7 @@ Custom classes for the component.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:41](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/BulkCheckboxControl.tsx#L41)
+[components/BulkCheckboxControl.tsx:41](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/BulkCheckboxControl.tsx#L41)
 
 ___
 
@@ -43,4 +43,4 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/BulkCheckboxControl.tsx#L26)
+[components/BulkCheckboxControl.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/BulkCheckboxControl.tsx#L26)

--- a/api/interfaces/components_DatatableWrapper.DatatableWrapperProps.md
+++ b/api/interfaces/components_DatatableWrapper.DatatableWrapperProps.md
@@ -35,7 +35,7 @@ The props that can be passed to the `DatatableWrapper` component.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:178](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L178)
+[components/DatatableWrapper.tsx:178](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L178)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:185](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L185)
+[components/DatatableWrapper.tsx:185](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L185)
 
 ___
 
@@ -57,7 +57,7 @@ The rest of the table, including its controls.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:176](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L176)
+[components/DatatableWrapper.tsx:176](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L176)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:181](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L181)
+[components/DatatableWrapper.tsx:181](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L181)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:177](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L177)
+[components/DatatableWrapper.tsx:177](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L177)
 
 ___
 
@@ -89,7 +89,7 @@ When set to `true`, the table will "skip" all uncontrolled processes.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:180](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L180)
+[components/DatatableWrapper.tsx:180](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L180)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:184](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L184)
+[components/DatatableWrapper.tsx:184](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L184)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:183](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L183)
+[components/DatatableWrapper.tsx:183](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L183)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:182](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L182)
+[components/DatatableWrapper.tsx:182](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L182)
 
 ___
 
@@ -134,4 +134,4 @@ and raising the `DatatableWrapper` a bit higher in the structure instead.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:192](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L192)
+[components/DatatableWrapper.tsx:192](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L192)

--- a/api/interfaces/components_DatatableWrapper.TableCheckboxParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableCheckboxParameters.md
@@ -23,4 +23,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:116](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L116)
+[components/DatatableWrapper.tsx:116](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L116)

--- a/api/interfaces/components_DatatableWrapper.TableFilterParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableFilterParameters.md
@@ -29,4 +29,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L38)
+[components/DatatableWrapper.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L38)

--- a/api/interfaces/components_DatatableWrapper.TablePaginationOptionsParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TablePaginationOptionsParameters.md
@@ -30,4 +30,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:102](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L102)
+[components/DatatableWrapper.tsx:102](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L102)

--- a/api/interfaces/components_DatatableWrapper.TablePaginationParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TablePaginationParameters.md
@@ -30,4 +30,4 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:83](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L83)
+[components/DatatableWrapper.tsx:83](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L83)

--- a/api/interfaces/components_DatatableWrapper.TableSortParameters.md
+++ b/api/interfaces/components_DatatableWrapper.TableSortParameters.md
@@ -30,7 +30,7 @@ The initial states for the table.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:74](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L74)
+[components/DatatableWrapper.tsx:74](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L74)
 
 ___
 
@@ -62,4 +62,4 @@ by number (milliseconds) instead of by formatted date string.
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:72](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L72)
+[components/DatatableWrapper.tsx:72](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L72)

--- a/api/interfaces/components_DatatableWrapper.UncontrolledTableEvents.md
+++ b/api/interfaces/components_DatatableWrapper.UncontrolledTableEvents.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:124](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L124)
+[components/DatatableWrapper.tsx:124](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L124)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:120](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L120)
+[components/DatatableWrapper.tsx:120](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L120)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:122](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L122)
+[components/DatatableWrapper.tsx:122](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L122)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:123](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L123)
+[components/DatatableWrapper.tsx:123](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L123)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:121](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L121)
+[components/DatatableWrapper.tsx:121](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L121)

--- a/api/interfaces/components_Filter.FilterClasses.md
+++ b/api/interfaces/components_Filter.FilterClasses.md
@@ -25,7 +25,7 @@ The class for the clear button.
 
 #### Defined in
 
-[components/Filter.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Filter.tsx#L20)
+[components/Filter.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Filter.tsx#L20)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the text input.
 
 #### Defined in
 
-[components/Filter.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Filter.tsx#L18)
+[components/Filter.tsx:18](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Filter.tsx#L18)
 
 ___
 
@@ -50,4 +50,4 @@ text input and the clear button.
 
 #### Defined in
 
-[components/Filter.tsx:16](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Filter.tsx#L16)
+[components/Filter.tsx:16](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Filter.tsx#L16)

--- a/api/interfaces/components_Filter.FilterProps.md
+++ b/api/interfaces/components_Filter.FilterProps.md
@@ -24,7 +24,7 @@ Custom classes for the component.
 
 #### Defined in
 
-[components/Filter.tsx:33](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Filter.tsx#L33)
+[components/Filter.tsx:33](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Filter.tsx#L33)
 
 ___
 
@@ -43,7 +43,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/Filter.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Filter.tsx#L35)
+[components/Filter.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Filter.tsx#L35)
 
 ___
 
@@ -56,4 +56,4 @@ By default, the text is "Enter text...".
 
 #### Defined in
 
-[components/Filter.tsx:31](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Filter.tsx#L31)
+[components/Filter.tsx:31](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Filter.tsx#L31)

--- a/api/interfaces/components_Pagination.PaginationClasses.md
+++ b/api/interfaces/components_Pagination.PaginationClasses.md
@@ -24,7 +24,7 @@ The class for each of the pagination button.
 
 #### Defined in
 
-[components/Pagination.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L26)
+[components/Pagination.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L26)
 
 ___
 
@@ -36,4 +36,4 @@ The class for the pagination button group.
 
 #### Defined in
 
-[components/Pagination.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L28)
+[components/Pagination.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L28)

--- a/api/interfaces/components_Pagination.PaginationLabels.md
+++ b/api/interfaces/components_Pagination.PaginationLabels.md
@@ -25,7 +25,7 @@ The "First" button label. Defaults to "First".
 
 #### Defined in
 
-[components/Pagination.tsx:11](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L11)
+[components/Pagination.tsx:11](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L11)
 
 ___
 
@@ -37,7 +37,7 @@ The "Last" button label. Defaults to "Last".
 
 #### Defined in
 
-[components/Pagination.tsx:13](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L13)
+[components/Pagination.tsx:13](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L13)
 
 ___
 
@@ -49,7 +49,7 @@ The "Next" button label. Defaults to "Next".
 
 #### Defined in
 
-[components/Pagination.tsx:17](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L17)
+[components/Pagination.tsx:17](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L17)
 
 ___
 
@@ -61,4 +61,4 @@ The "Prev" button label. Defaults to "Prev".
 
 #### Defined in
 
-[components/Pagination.tsx:15](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L15)
+[components/Pagination.tsx:15](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L15)

--- a/api/interfaces/components_Pagination.PaginationProps.md
+++ b/api/interfaces/components_Pagination.PaginationProps.md
@@ -28,7 +28,7 @@ To prevent layout shifts, `visibility: hidden` will be applied instead of
 
 #### Defined in
 
-[components/Pagination.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L45)
+[components/Pagination.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L45)
 
 ___
 
@@ -40,7 +40,7 @@ Customize the classes of the `Pagination` component.
 
 #### Defined in
 
-[components/Pagination.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L38)
+[components/Pagination.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L38)
 
 ___
 
@@ -60,7 +60,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/Pagination.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L47)
+[components/Pagination.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L47)
 
 ___
 
@@ -72,4 +72,4 @@ Customize the labels of the `Pagination` component.
 
 #### Defined in
 
-[components/Pagination.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L36)
+[components/Pagination.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L36)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsClasses.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsClasses.md
@@ -25,7 +25,7 @@ The class for the select input.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L36)
+[components/PaginationOptions.tsx:36](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L36)
 
 ___
 
@@ -38,7 +38,7 @@ the `beforeSelect` label, the select input, and the `afterSelect` text.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L32)
+[components/PaginationOptions.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L32)
 
 ___
 
@@ -50,4 +50,4 @@ The class for the `beforeSelect` and `afterSelect` labels.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L34)
+[components/PaginationOptions.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L34)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsLabels.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsLabels.md
@@ -25,7 +25,7 @@ is a horizontal form instead of vertical (e.g. using `flex-direction: row`).
 
 #### Defined in
 
-[components/PaginationOptions.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L20)
+[components/PaginationOptions.tsx:20](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L20)
 
 ___
 
@@ -38,4 +38,4 @@ Defaults to "Rows per page".
 
 #### Defined in
 
-[components/PaginationOptions.tsx:14](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L14)
+[components/PaginationOptions.tsx:14](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L14)

--- a/api/interfaces/components_PaginationOptions.PaginationOptionsProps.md
+++ b/api/interfaces/components_PaginationOptions.PaginationOptionsProps.md
@@ -28,7 +28,7 @@ To prevent layout shifts, `visibility: hidden` will be applied instead of
 
 #### Defined in
 
-[components/PaginationOptions.tsx:53](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L53)
+[components/PaginationOptions.tsx:53](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L53)
 
 ___
 
@@ -40,7 +40,7 @@ Customize the classes of the `PaginationOptions` component.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L46)
+[components/PaginationOptions.tsx:46](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L46)
 
 ___
 
@@ -61,7 +61,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:55](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L55)
+[components/PaginationOptions.tsx:55](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L55)
 
 ___
 
@@ -73,4 +73,4 @@ Customize the labels of the `PaginationOptions` component.
 
 #### Defined in
 
-[components/PaginationOptions.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L44)
+[components/PaginationOptions.tsx:44](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L44)

--- a/api/interfaces/components_TableBody.TableBodyClasses.md
+++ b/api/interfaces/components_TableBody.TableBodyClasses.md
@@ -25,7 +25,7 @@ The class for the `tbody` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L28)
+[components/TableBody.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L28)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the `td` tags inside each `tr` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L32)
+[components/TableBody.tsx:32](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L32)
 
 ___
 
@@ -49,4 +49,4 @@ The class for the `tr` tags inside `tbody`.
 
 #### Defined in
 
-[components/TableBody.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L30)
+[components/TableBody.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L30)

--- a/api/interfaces/components_TableBody.TableBodyLabels.md
+++ b/api/interfaces/components_TableBody.TableBodyLabels.md
@@ -23,4 +23,4 @@ no data (empty array), or no matching found for the filtered text.
 
 #### Defined in
 
-[components/TableBody.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L19)
+[components/TableBody.tsx:19](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L19)

--- a/api/interfaces/components_TableBody.TableBodyProps.md
+++ b/api/interfaces/components_TableBody.TableBodyProps.md
@@ -35,7 +35,7 @@ Customize the classes of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L47)
+[components/TableBody.tsx:47](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L47)
 
 ___
 
@@ -55,7 +55,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/TableBody.tsx:53](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L53)
+[components/TableBody.tsx:53](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L53)
 
 ___
 
@@ -67,7 +67,7 @@ Customize the labels of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L45)
+[components/TableBody.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L45)
 
 ___
 
@@ -79,7 +79,7 @@ The props passed to the table rows under `tbody`.
 
 #### Defined in
 
-[components/TableBody.tsx:49](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L49)
+[components/TableBody.tsx:49](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L49)
 
 ## Methods
 
@@ -101,4 +101,4 @@ The function fired when any of the rows is clicked.
 
 #### Defined in
 
-[components/TableBody.tsx:51](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L51)
+[components/TableBody.tsx:51](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L51)

--- a/api/interfaces/components_TableHeader.TableHeaderClasses.md
+++ b/api/interfaces/components_TableHeader.TableHeaderClasses.md
@@ -21,11 +21,11 @@ the `TableHeaderClasses` component.
 
 • `Optional` **th**: `string`
 
-The class for the `th` tags inside each `tr` tag.
+The class for all `th` tags inside each `tr` tag.
 
 #### Defined in
 
-[components/TableHeader.tsx:29](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableHeader.tsx#L29)
+[components/TableHeader.tsx:29](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableHeader.tsx#L29)
 
 ___
 
@@ -37,7 +37,7 @@ The class for the `thead` tag.
 
 #### Defined in
 
-[components/TableHeader.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableHeader.tsx#L25)
+[components/TableHeader.tsx:25](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableHeader.tsx#L25)
 
 ___
 
@@ -45,8 +45,8 @@ ___
 
 • `Optional` **tr**: `string`
 
-The class for the `tr` tags inside `tbody`.
+The class for all `tr` tags inside `tbody`.
 
 #### Defined in
 
-[components/TableHeader.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableHeader.tsx#L27)
+[components/TableHeader.tsx:27](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableHeader.tsx#L27)

--- a/api/interfaces/components_TableHeader.TableHeaderProps.md
+++ b/api/interfaces/components_TableHeader.TableHeaderProps.md
@@ -23,7 +23,7 @@ Customize the classes of the `TableHeader` component.
 
 #### Defined in
 
-[components/TableHeader.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableHeader.tsx#L37)
+[components/TableHeader.tsx:37](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableHeader.tsx#L37)
 
 ___
 
@@ -45,4 +45,4 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/TableHeader.tsx:39](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableHeader.tsx#L39)
+[components/TableHeader.tsx:39](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableHeader.tsx#L39)

--- a/api/interfaces/helpers_types.CheckboxState.md
+++ b/api/interfaces/helpers_types.CheckboxState.md
@@ -25,7 +25,7 @@ the behavior of the `Set` type.
 
 #### Defined in
 
-[helpers/types.ts:25](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L25)
+[helpers/types.ts:30](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L30)
 
 ___
 
@@ -38,4 +38,4 @@ The checkbox states. This is useful to determine the "Select all" and
 
 #### Defined in
 
-[helpers/types.ts:30](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L30)
+[helpers/types.ts:35](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L35)

--- a/api/interfaces/helpers_types.SortType.md
+++ b/api/interfaces/helpers_types.SortType.md
@@ -23,7 +23,7 @@ The sort order.
 
 #### Defined in
 
-[helpers/types.ts:13](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L13)
+[helpers/types.ts:18](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L18)
 
 ___
 
@@ -36,4 +36,4 @@ This is the same as `header.prop` from `TableColumnType` interface.
 
 #### Defined in
 
-[helpers/types.ts:11](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L11)
+[helpers/types.ts:16](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L16)

--- a/api/interfaces/helpers_types.TableColumnType.md
+++ b/api/interfaces/helpers_types.TableColumnType.md
@@ -23,6 +23,7 @@ prop of the `DatatableWrapper` props, as well as the `TableHeader` props.
 - [isFilterable](helpers_types.TableColumnType.md#isfilterable)
 - [isSortable](helpers_types.TableColumnType.md#issortable)
 - [prop](helpers_types.TableColumnType.md#prop)
+- [thProps](helpers_types.TableColumnType.md#thprops)
 - [title](helpers_types.TableColumnType.md#title)
 
 ### Methods
@@ -48,7 +49,7 @@ the same thing.
 
 #### Defined in
 
-[helpers/types.ts:90](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L90)
+[helpers/types.ts:98](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L98)
 
 ___
 
@@ -67,7 +68,7 @@ The props passed to the table columns under `tbody`.
 
 #### Defined in
 
-[helpers/types.ts:53](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L53)
+[helpers/types.ts:61](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L61)
 
 ___
 
@@ -87,7 +88,7 @@ the column will be a checkbox, both the headers and the rest of the rows.
 
 #### Defined in
 
-[helpers/types.ts:79](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L79)
+[helpers/types.ts:87](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L87)
 
 ___
 
@@ -101,7 +102,7 @@ will not be rendered.
 
 #### Defined in
 
-[helpers/types.ts:70](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L70)
+[helpers/types.ts:78](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L78)
 
 ___
 
@@ -113,7 +114,7 @@ Determines whether the column is sortable or not.
 
 #### Defined in
 
-[helpers/types.ts:74](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L74)
+[helpers/types.ts:82](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L82)
 
 ___
 
@@ -127,7 +128,19 @@ have unique `prop` field.
 
 #### Defined in
 
-[helpers/types.ts:43](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L43)
+[helpers/types.ts:48](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L48)
+
+___
+
+### thProps
+
+• `Optional` **thProps**: `ThHTMLAttributes`<`HTMLTableCellElement`\>
+
+The props passed to the table headers under `tbody`.
+
+#### Defined in
+
+[helpers/types.ts:58](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L58)
 
 ___
 
@@ -139,7 +152,7 @@ The title for the header.
 
 #### Defined in
 
-[helpers/types.ts:45](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L45)
+[helpers/types.ts:50](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L50)
 
 ## Methods
 
@@ -161,7 +174,7 @@ Custom render the table body cell. This is a function with the row data as param
 
 #### Defined in
 
-[helpers/types.ts:51](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L51)
+[helpers/types.ts:56](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L56)
 
 ___
 
@@ -184,4 +197,4 @@ Custom render the table header cell.
 
 #### Defined in
 
-[helpers/types.ts:47](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L47)
+[helpers/types.ts:52](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L52)

--- a/api/modules/components_BulkCheckboxControl.md
+++ b/api/modules/components_BulkCheckboxControl.md
@@ -38,4 +38,4 @@ change to "Deselect all" button.
 
 #### Defined in
 
-[components/BulkCheckboxControl.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/BulkCheckboxControl.tsx#L52)
+[components/BulkCheckboxControl.tsx:52](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/BulkCheckboxControl.tsx#L52)

--- a/api/modules/components_DatatableWrapper.md
+++ b/api/modules/components_DatatableWrapper.md
@@ -42,4 +42,4 @@
 
 #### Defined in
 
-[components/DatatableWrapper.tsx:225](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/DatatableWrapper.tsx#L225)
+[components/DatatableWrapper.tsx:225](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/DatatableWrapper.tsx#L225)

--- a/api/modules/components_Filter.md
+++ b/api/modules/components_Filter.md
@@ -35,4 +35,4 @@ prop. Otherwise, this component will return `null`.
 
 #### Defined in
 
-[components/Filter.tsx:48](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Filter.tsx#L48)
+[components/Filter.tsx:48](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Filter.tsx#L48)

--- a/api/modules/components_Pagination.md
+++ b/api/modules/components_Pagination.md
@@ -41,4 +41,4 @@ When `alwaysShowPagination` is set to `false`, then this component will be visua
 
 #### Defined in
 
-[components/Pagination.tsx:71](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/Pagination.tsx#L71)
+[components/Pagination.tsx:71](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/Pagination.tsx#L71)

--- a/api/modules/components_PaginationOptions.md
+++ b/api/modules/components_PaginationOptions.md
@@ -42,4 +42,4 @@ When `alwaysShowPagination` is set to `false`, then this component will be visua
 
 #### Defined in
 
-[components/PaginationOptions.tsx:81](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/PaginationOptions.tsx#L81)
+[components/PaginationOptions.tsx:81](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/PaginationOptions.tsx#L81)

--- a/api/modules/components_TableBody.md
+++ b/api/modules/components_TableBody.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[components/TableBody.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L35)
+[components/TableBody.tsx:35](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L35)
 
 ## Functions
 
@@ -55,4 +55,4 @@ such as `tr` and `td` tags.
 
 #### Defined in
 
-[components/TableBody.tsx:73](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableBody.tsx#L73)
+[components/TableBody.tsx:73](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableBody.tsx#L73)

--- a/api/modules/components_TableHeader.md
+++ b/api/modules/components_TableHeader.md
@@ -33,4 +33,4 @@ Renders a list of table headers.
 
 #### Defined in
 
-[components/TableHeader.tsx:62](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/components/TableHeader.tsx#L62)
+[components/TableHeader.tsx:62](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/components/TableHeader.tsx#L62)

--- a/api/modules/helpers_types.md
+++ b/api/modules/helpers_types.md
@@ -49,7 +49,7 @@ The helper type for the checkbox change eveent.
 
 #### Defined in
 
-[helpers/types.ts:144](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L144)
+[helpers/types.ts:152](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L152)
 
 ___
 
@@ -73,7 +73,7 @@ can make the sort result incorrect, e.g. sorting formatted dates.
 
 #### Defined in
 
-[helpers/types.ts:105](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L105)
+[helpers/types.ts:113](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L113)
 
 ___
 
@@ -99,7 +99,7 @@ The helper type for the filter change event.
 
 #### Defined in
 
-[helpers/types.ts:119](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L119)
+[helpers/types.ts:127](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L127)
 
 ___
 
@@ -125,7 +125,7 @@ The helper type for the sort by prop change event.
 
 #### Defined in
 
-[helpers/types.ts:134](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L134)
+[helpers/types.ts:142](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L142)
 
 ___
 
@@ -151,7 +151,7 @@ The helper type for the rows per page change event.
 
 #### Defined in
 
-[helpers/types.ts:139](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L139)
+[helpers/types.ts:147](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L147)
 
 ___
 
@@ -177,7 +177,7 @@ The helper type for the sort by prop change event.
 
 #### Defined in
 
-[helpers/types.ts:129](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L129)
+[helpers/types.ts:137](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L137)
 
 ___
 
@@ -203,7 +203,7 @@ The helper type for the sort by next prop change event.
 
 #### Defined in
 
-[helpers/types.ts:124](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L124)
+[helpers/types.ts:132](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L132)
 
 ___
 
@@ -221,4 +221,4 @@ This is used for the `extend` keyword in the components.
 
 #### Defined in
 
-[helpers/types.ts:112](https://github.com/imballinst/react-bs-datatable/blob/8a8b804/src/helpers/types.ts#L112)
+[helpers/types.ts:120](https://github.com/imballinst/react-bs-datatable/blob/5f07b72/src/helpers/types.ts#L120)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bs-datatable",
-  "version": "3.3.1",
+  "version": "3.4.0-alpha.0",
   "description": "React Bootstrap Datatable (without jQuery) with sorting, filter, and pagination",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/__stories__/00-Uncontrolled.stories.tsx
+++ b/src/__stories__/00-Uncontrolled.stories.tsx
@@ -148,6 +148,43 @@ CustomTableRowProps.args = {
   })
 };
 
+// TODO(imballinst): migrate all stories so they are composable like this,
+// instead of adding all to StoryTable props which can result in unmaintainability.
+export const CustomThProps = (() => {
+  function CustomThPropsTemplate({ thClassName }: { thClassName?: string }) {
+    const headers: TableColumnType<StoryColumnType>[] = STORY_HEADERS.map(
+      (header) => ({
+        ...header,
+        thProps:
+          header.prop === 'score'
+            ? {
+                className: thClassName
+              }
+            : undefined
+      })
+    );
+
+    return (
+      <DatatableWrapper body={json} headers={headers}>
+        <Table>
+          <TableHeader />
+          <TableBody />
+        </Table>
+      </DatatableWrapper>
+    );
+  }
+
+  return CustomThPropsTemplate as ComponentStory<typeof CustomThPropsTemplate>;
+})();
+CustomThProps.storyName = 'Custom "score" table header classname';
+CustomThProps.argTypes = {
+  thClassName: {
+    name: '"Score" table header classname',
+    type: 'string',
+    defaultValue: 'hello-world'
+  }
+};
+
 export const RowOnClick = Template.bind({});
 RowOnClick.storyName = 'Adding row on click event';
 RowOnClick.argTypes = {

--- a/src/__stories__/00-Uncontrolled.test.tsx
+++ b/src/__stories__/00-Uncontrolled.test.tsx
@@ -8,8 +8,26 @@ import {
   CustomTableRowProps,
   RowOnClick,
   UncontrolledWithRefEvents,
-  RaisedTableContext
+  RaisedTableContext,
+  CustomThProps
 } from './00-Uncontrolled.stories';
+
+describe('Basic use cases', () => {
+  test('thProps', () => {
+    const { getByRole } = render(<CustomThProps thClassName="th--score" />);
+
+    let tableElement = getByRole('table');
+
+    expect(
+      tableElement
+        .querySelector('thead')
+        ?.querySelectorAll('tr')
+        .item(0)
+        .querySelectorAll('th')
+        .item(4).className
+    ).toBe('thead-th th--score');
+  });
+});
 
 describe('Filter, sort, pagination', () => {
   const DEFAULT_PROPS = {

--- a/src/components/TableHeader.tsx
+++ b/src/components/TableHeader.tsx
@@ -23,9 +23,9 @@ import { getNextSortState } from '../helpers/data';
 export interface TableHeaderClasses {
   /** The class for the `thead` tag. */
   thead?: string;
-  /** The class for the `tr` tags inside `tbody`. */
+  /** The class for all `tr` tags inside `tbody`. */
   tr?: string;
-  /** The class for the `th` tags inside each `tr` tag. */
+  /** The class for all `th` tags inside each `tr` tag. */
   th?: string;
 }
 
@@ -83,13 +83,15 @@ export function TableHeader({ classes, controlledProps }: TableHeaderProps) {
   for (let i = 0; i < headers.length; i += 1) {
     const {
       isSortable,
-      prop: headerProp,
+      prop: rawProp,
       title,
       headerCell,
+      thProps: additionalThProps = {},
       checkbox,
       alignment
     } = headers[i];
-    const prop = headerProp.toString();
+    const prop = rawProp.toString();
+    const { className: headerPropsClassName, ...rest } = additionalThProps;
 
     const thClass = makeClasses({
       'thead-th': true,
@@ -101,13 +103,15 @@ export function TableHeader({ classes, controlledProps }: TableHeaderProps) {
       className: makeClasses(
         thClass,
         classes?.th,
+        headerPropsClassName,
         // Alignment.
         {
           'text-start': alignment?.horizontal === 'left',
           'text-center': alignment?.horizontal === 'center',
           'text-end': alignment?.horizontal === 'right'
         }
-      )
+      ),
+      ...rest
     };
     let sortIcon: 'sort' | 'sortUp' | 'sortDown' = 'sort';
     let sortIconRender = null;

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,4 +1,9 @@
-import { CSSProperties, MutableRefObject, ReactNode } from 'react';
+import {
+  CSSProperties,
+  MutableRefObject,
+  ReactNode,
+  ThHTMLAttributes
+} from 'react';
 
 /**
  * The sort type used in the states.
@@ -49,6 +54,9 @@ export interface TableColumnType<T> {
    * Custom render the table body cell. This is a function with the row data as parameter.
    */
   cell?: (row: T) => ReactNode;
+  /** The props passed to the table headers under `tbody`. */
+  thProps?: ThHTMLAttributes<HTMLTableCellElement>;
+  // TODO(imballinst): update `cellProps` to return entire props like `thProps` above.
   /** The props passed to the table columns under `tbody`. */
   cellProps?: {
     /**


### PR DESCRIPTION
Addresses https://github.com/imballinst/react-bs-datatable/issues/138. Example usage:

```ts
const headers: TableColumnType<Something>[] = [
  {
    prop: 'test',
    title: 'Test',
    thProps: {
      className: 'hello-world',
      'data-value-something': 'test'
    }
  }
]
```