### PR TITLE
Rename Filter.onFilter to Filter.onFilterChange

### DIFF
--- a/src/__stories__/01-Controlled.stories.tsx
+++ b/src/__stories__/01-Controlled.stories.tsx
@@ -87,7 +87,7 @@ const ControlledComposedTableRowTemplate: ComponentStory<
   const [rowsPerPage, setRowsPerPage] = useState(rowsPerPageProp);
   const [maxPage, setMaxPage] = useState(1);
 
-  const onFilter = useCallback((text) => {
+  const onFilterChange = useCallback((text) => {
     setFilter(text);
     setCurrentPage(1);
   }, []);
@@ -139,7 +139,7 @@ const ControlledComposedTableRowTemplate: ComponentStory<
           lg={4}
           className="d-flex flex-col justify-content-end align-items-end"
         >
-          <Filter controlledProps={{ filter, onFilter }} />
+          <Filter controlledProps={{ filter, onFilterChange }} />
         </Col>
         <Col
           xs={12}
@@ -233,7 +233,7 @@ function AsyncStoryTable<TTableRowType = any>({
   const [rowsPerPage, setRowsPerPage] = useState(rowsPerPageProp);
   const [maxPage, setMaxPage] = useState(1);
 
-  const onFilter = useCallback((text) => {
+  const onFilterChange = useCallback((text) => {
     setFilter(text);
     setCurrentPage(1);
   }, []);
@@ -277,7 +277,7 @@ function AsyncStoryTable<TTableRowType = any>({
           lg={4}
           className="d-flex flex-col justify-content-end align-items-end"
         >
-          <Filter controlledProps={{ filter, onFilter }} />
+          <Filter controlledProps={{ filter, onFilterChange }} />
         </Col>
         <Col
           xs={12}

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -36,6 +36,12 @@ export interface FilterProps {
     /** The text filter. */
     filter?: string;
     /** The function fired when the text filter changes. */
+    onFilterChange?: FilterOnChange;
+    /**
+     * @deprecated
+     *
+     * Usage of `onFilter` is deprecated. Consider using `onFilterChange` instead.
+     */
     onFilter?: FilterOnChange;
   };
 }
@@ -60,8 +66,13 @@ export function Filter({
     return null;
   }
 
-  // Controlled has the bigger priority.
-  const onFilterChange = controlledProps?.onFilter || onFilterChangeContext;
+  /**
+   * Controlled has the bigger priority.
+   * Supports @deprecated onFilter
+   */
+  const onFilterChange = controlledProps?.onFilterChange
+      || controlledProps?.onFilter
+      || onFilterChangeContext;
   const filterState = controlledProps?.filter || filterStateContext;
 
   return (


### PR DESCRIPTION
All of the other components props for onChange have the suffix, so I thought it would be good to have in this one as well, I  `@deprecated` the `onFilter`, kept support for it but `onFilterChange` have priority. Let me know if more changes needed!