### PR TITLE
feat: allow to make the table controlled without having to pass isControlled; deprecate isControlled

### DIFF
--- a/src/__stories__/01-Controlled.stories.tsx
+++ b/src/__stories__/01-Controlled.stories.tsx
@@ -132,7 +132,7 @@ const ControlledComposedTableRowTemplate: ComponentStory<
   }, [filter, sortState, currentPage, rowsPerPage]);
 
   return (
-    <DatatableWrapper headers={CONTROLLED_HEADERS} body={data} isControlled>
+    <DatatableWrapper headers={CONTROLLED_HEADERS} body={data}>
       <Row className="mb-4">
         <Col
           xs={12}
@@ -270,7 +270,7 @@ function AsyncStoryTable<TTableRowType = any>({
   }, [fetchFn, filter, sortState, currentPage, rowsPerPage]);
 
   return (
-    <DatatableWrapper headers={headers} body={data} isControlled>
+    <DatatableWrapper headers={headers} body={data}>
       <Row className="mb-4">
         <Col
           xs={12}

--- a/src/components/DatatableWrapper.tsx
+++ b/src/components/DatatableWrapper.tsx
@@ -132,6 +132,7 @@ export interface UncontrolledTableEvents {
 interface DatatableWrapperContextType<TTableRowType> {
   // Things passed to other components.
   headers: TableColumnType<TTableRowType>[];
+  setIsControlled: React.Dispatch<React.SetStateAction<boolean>>;
   // Filter.
   isFilterable: boolean;
   filterState: string;
@@ -176,7 +177,12 @@ export interface DatatableWrapperProps<TTableRowType> {
   children: ReactNode;
   headers: TableColumnType<TTableRowType>[];
   body: TTableRowType[];
-  /** When set to `true`, the table will "skip" all uncontrolled processes. */
+  /**
+   * @deprecated
+   *
+   * This prop is deprecated; now the table is automatically set as controlled
+   * when any of the child components is provided `controlledProps`.
+   */
   isControlled?: boolean;
   filterProps?: TableFilterParameters;
   sortProps?: TableSortParameters<TTableRowType>;
@@ -225,7 +231,7 @@ interface DatatableState {
 export function DatatableWrapper<TTableRowType = any>({
   headers,
   body,
-  isControlled,
+  isControlled: isControlledProp,
   filterProps,
   sortProps,
   paginationProps,
@@ -244,6 +250,7 @@ export function DatatableWrapper<TTableRowType = any>({
       checkboxProps
     })
   );
+  const [isControlled, setIsControlled] = useState(isControlledProp || false);
   const headersRecordRef = useRef(convertArrayToRecord(headers, 'prop'));
   // Store this in a ref because we might need it in case `headers` change.
   // Though, we don't want to put these into `useEffect` because they most likely
@@ -425,6 +432,7 @@ export function DatatableWrapper<TTableRowType = any>({
     <Provider
       value={{
         headers,
+        setIsControlled,
         // Filter.
         isFilterable: isFilterable,
         filterState: filter,

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { InputGroup, Form, Button } from 'react-bootstrap';
+import { useControlledStateSetter } from '../helpers/hooks';
 import { FilterOnChange } from '../helpers/types';
 import { useDatatableWrapper } from './DatatableWrapper';
 import FontAwesome from './FontAwesome';
@@ -61,6 +62,7 @@ export function Filter({
     onFilterChange: onFilterChangeContext,
     isFilterable
   } = useDatatableWrapper();
+  useControlledStateSetter(controlledProps);
 
   if (!isFilterable) {
     return null;
@@ -70,9 +72,10 @@ export function Filter({
    * Controlled has the bigger priority.
    * Supports @deprecated onFilter
    */
-  const onFilterChange = controlledProps?.onFilterChange
-      || controlledProps?.onFilter
-      || onFilterChangeContext;
+  const onFilterChange =
+    controlledProps?.onFilterChange ||
+    controlledProps?.onFilter ||
+    onFilterChangeContext;
   const filterState = controlledProps?.filter || filterStateContext;
 
   return (

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button, ButtonGroup } from 'react-bootstrap';
+import { useControlledStateSetter } from '../helpers/hooks';
 
 import { makeClasses } from '../helpers/object';
 import { PaginationOnChange } from '../helpers/types';
@@ -79,6 +80,7 @@ export function Pagination({
     maxPage: maxPageContext,
     onPaginationChange: onPaginationChangeContext
   } = useDatatableWrapper();
+  useControlledStateSetter(controlledProps);
 
   // Controlled has the bigger priority.
   const currentPageState =

--- a/src/components/PaginationOptions.tsx
+++ b/src/components/PaginationOptions.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Form } from 'react-bootstrap';
+import { useControlledStateSetter } from '../helpers/hooks';
 
 import { makeClasses } from '../helpers/object';
 import { RowsPerPageOnChange } from '../helpers/types';
@@ -90,6 +91,7 @@ export function PaginationOptions({
     rowsPerPageState: rowsPerPageStateContext,
     filteredDataLength: filteredDataLengthContext
   } = useDatatableWrapper();
+  useControlledStateSetter(controlledProps);
 
   // Controlled has the bigger priority.
   const rowsPerPageOptions =

--- a/src/components/TableBody.tsx
+++ b/src/components/TableBody.tsx
@@ -9,6 +9,7 @@ import {
 import { makeClasses } from '../helpers/object';
 import { useDatatableWrapper } from './DatatableWrapper';
 import { getNextCheckboxState } from '../helpers/checkbox';
+import { useControlledStateSetter } from '../helpers/hooks';
 
 export interface TableBodyLabels {
   /**
@@ -91,6 +92,8 @@ export function TableBody<TTableRowType extends TableRowType>({
     filteredDataLength: filteredDataLengthContext,
     checkboxRefs
   } = useDatatableWrapper();
+  useControlledStateSetter(controlledProps);
+
   let bodyContent: JSX.Element | JSX.Element[];
 
   if (children) {

--- a/src/components/TableHeader.tsx
+++ b/src/components/TableHeader.tsx
@@ -15,6 +15,7 @@ import {
   GetNextCheckboxStateParams
 } from '../helpers/checkbox';
 import { getNextSortState } from '../helpers/data';
+import { useControlledStateSetter } from '../helpers/hooks';
 
 /**
  * This is an interface for customizing the classes for
@@ -71,6 +72,7 @@ export function TableHeader({ classes, controlledProps }: TableHeaderProps) {
     filteredDataLength: filteredDataLengthContext,
     data
   } = useDatatableWrapper();
+  useControlledStateSetter(controlledProps);
 
   const onSortChange = controlledProps?.onSortChange || onSortChangeContext;
   const sortState = controlledProps?.sortState || sortStateContext;

--- a/src/helpers/hooks.ts
+++ b/src/helpers/hooks.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+import { useDatatableWrapper } from '../components/DatatableWrapper';
+
+export function useControlledStateSetter<ControlledPropsType extends object>(
+  controlledProps: ControlledPropsType | undefined
+) {
+  // Make this only run once.
+  const { setIsControlled } = useDatatableWrapper();
+  const ref = useRef(controlledProps);
+  useEffect(() => {
+    if (ref.current !== undefined) {
+      setIsControlled(true);
+    }
+  }, []);
+}


### PR DESCRIPTION
Fixes https://github.com/imballinst/react-bs-datatable/issues/150.