### PR TITLE
chore: allow node above 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
   },
   "dependencies": {},
   "engines": {
-    "node": "16"
+    "node": ">=16"
   }
 }


### PR DESCRIPTION
Before:

```
@imballinst ➜ /workspaces/react-bs-datatable (allow-node-above-16) $ yarn
yarn install v1.22.19
[1/5] Validating package.json...
error react-bs-datatable@3.8.0: The engine "node" is incompatible with this module. Expected version "16". Got "18.15.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

After:

```
@imballinst ➜ /workspaces/react-bs-datatable (allow-node-above-16) $ yarn
yarn install v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
[4/5] Linking dependencies...
warning " > babel-loader@8.2.3" has unmet peer dependency "webpack@>=2".
warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/core-client@6.4.14" has unmet peer dependency "webpack@*".
warning " > @storybook/testing-react@1.2.3" has unmet peer dependency "@storybook/addons@>=6.4.0".
warning " > @storybook/testing-react@1.2.3" has unmet peer dependency "@storybook/client-api@>=6.4.0".
warning " > @storybook/testing-react@1.2.3" has unmet peer dependency "@storybook/preview-web@>=6.4.0".
warning " > bootstrap@5.1.3" has unmet peer dependency "@popperjs/core@^2.10.2".
warning Workspaces can only be enabled in private projects.
[5/5] Building fresh packages...
```