### PR TITLE
feat: allow customizing valid tag names for onRowClick in TableBody and TableBodyRow

### DIFF
--- a/api/interfaces/components_TableBody.EmptyTablePlaceholderProps.md
+++ b/api/interfaces/components_TableBody.EmptyTablePlaceholderProps.md
@@ -23,7 +23,7 @@ The className to pass to the component.
 
 #### Defined in
 
-[components/TableBody.tsx:331](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L331)
+[components/TableBody.tsx:350](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L350)
 
 ___
 
@@ -35,4 +35,4 @@ The label that will show up when the table is empty.
 
 #### Defined in
 
-[components/TableBody.tsx:333](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L333)
+[components/TableBody.tsx:352](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L352)

--- a/api/interfaces/components_TableBody.TableBodyClasses.md
+++ b/api/interfaces/components_TableBody.TableBodyClasses.md
@@ -22,7 +22,7 @@ The class for the `tbody` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L26)
+[components/TableBody.tsx:39](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L39)
 
 ___
 
@@ -34,7 +34,7 @@ The class for the `td` tags inside each `tr` tag.
 
 #### Defined in
 
-[components/TableBody.tsx:30](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L30)
+[components/TableBody.tsx:43](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L43)
 
 ___
 
@@ -46,4 +46,4 @@ The class for the `tr` tags inside `tbody`.
 
 #### Defined in
 
-[components/TableBody.tsx:28](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L28)
+[components/TableBody.tsx:41](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L41)

--- a/api/interfaces/components_TableBody.TableBodyControlledProps.md
+++ b/api/interfaces/components_TableBody.TableBodyControlledProps.md
@@ -23,7 +23,7 @@ is of type `CheckboxState`.
 
 #### Defined in
 
-[components/TableBody.tsx:38](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L38)
+[components/TableBody.tsx:51](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L51)
 
 ___
 
@@ -36,7 +36,7 @@ then this should equal to the table body's length.
 
 #### Defined in
 
-[components/TableBody.tsx:45](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L45)
+[components/TableBody.tsx:58](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L58)
 
 ___
 
@@ -48,4 +48,4 @@ The function fired when any checkbox in the table changes.
 
 #### Defined in
 
-[components/TableBody.tsx:40](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L40)
+[components/TableBody.tsx:53](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L53)

--- a/api/interfaces/components_TableBody.TableBodyLabels.md
+++ b/api/interfaces/components_TableBody.TableBodyLabels.md
@@ -21,4 +21,4 @@ no data (empty array), or no matching found for the filtered text.
 
 #### Defined in
 
-[components/TableBody.tsx:21](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L21)
+[components/TableBody.tsx:34](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L34)

--- a/api/interfaces/components_TableBody.TableBodyProps.md
+++ b/api/interfaces/components_TableBody.TableBodyProps.md
@@ -12,6 +12,12 @@ This is an interface for `TableBody` component props.
 | :------ | :------ |
 | `TTableRowType` | extends [`TableRowType`](../modules/helpers_types.md#tablerowtype) |
 
+## Hierarchy
+
+- `CommonProps`
+
+  ↳ **`TableBodyProps`**
+
 ## Table of contents
 
 ### Properties
@@ -21,6 +27,7 @@ This is an interface for `TableBody` component props.
 - [controlledProps](components_TableBody.TableBodyProps.md#controlledprops)
 - [labels](components_TableBody.TableBodyProps.md#labels)
 - [rowProps](components_TableBody.TableBodyProps.md#rowprops)
+- [validRowClickTagNames](components_TableBody.TableBodyProps.md#validrowclicktagnames)
 
 ### Methods
 
@@ -36,7 +43,7 @@ The function to customize the table rows.
 
 #### Defined in
 
-[components/TableBody.tsx:74](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L74)
+[components/TableBody.tsx:88](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L88)
 
 ___
 
@@ -48,7 +55,7 @@ Customize the classes of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:63](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L63)
+[components/TableBody.tsx:77](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L77)
 
 ___
 
@@ -60,7 +67,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/TableBody.tsx:72](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L72)
+[components/TableBody.tsx:86](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L86)
 
 ___
 
@@ -72,7 +79,7 @@ Customize the labels of the `TableBody` component.
 
 #### Defined in
 
-[components/TableBody.tsx:61](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L61)
+[components/TableBody.tsx:75](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L75)
 
 ___
 
@@ -84,7 +91,27 @@ The props passed to the table rows under `tbody`.
 
 #### Defined in
 
-[components/TableBody.tsx:65](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L65)
+[components/TableBody.tsx:79](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L79)
+
+___
+
+### validRowClickTagNames
+
+• `Optional` **validRowClickTagNames**: ``"*"`` \| `string`[]
+
+Customize the tag names that will trigger the row onClick. Defaults to ['TR', 'TD'].
+For more information, please visit the [tagName documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName).
+
+Other than an array of tag names, you can also pass a string "*" to indicate that all child elements
+will trigger the row on click event.
+
+#### Inherited from
+
+CommonProps.validRowClickTagNames
+
+#### Defined in
+
+[components/TableBody.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L26)
 
 ## Methods
 
@@ -107,4 +134,4 @@ The function fired when any of the rows is clicked.
 
 #### Defined in
 
-[components/TableBody.tsx:67](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L67)
+[components/TableBody.tsx:81](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L81)

--- a/api/interfaces/components_TableBody.TableRowProps.md
+++ b/api/interfaces/components_TableBody.TableRowProps.md
@@ -12,6 +12,12 @@ The props for the `TableRow` component.
 | :------ | :------ |
 | `TTableRowType` | extends [`TableRowType`](../modules/helpers_types.md#tablerowtype) |
 
+## Hierarchy
+
+- `CommonProps`
+
+  ↳ **`TableRowProps`**
+
 ## Table of contents
 
 ### Properties
@@ -21,6 +27,7 @@ The props for the `TableRow` component.
 - [rowData](components_TableBody.TableRowProps.md#rowdata)
 - [rowIdx](components_TableBody.TableRowProps.md#rowidx)
 - [rowProps](components_TableBody.TableRowProps.md#rowprops)
+- [validRowClickTagNames](components_TableBody.TableRowProps.md#validrowclicktagnames)
 
 ### Methods
 
@@ -36,7 +43,7 @@ Classes for the rows and columns.
 
 #### Defined in
 
-[components/TableBody.tsx:158](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L158)
+[components/TableBody.tsx:174](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L174)
 
 ___
 
@@ -48,7 +55,7 @@ Props to make the component controlled.
 
 #### Defined in
 
-[components/TableBody.tsx:160](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L160)
+[components/TableBody.tsx:176](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L176)
 
 ___
 
@@ -60,7 +67,7 @@ The row data.
 
 #### Defined in
 
-[components/TableBody.tsx:149](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L149)
+[components/TableBody.tsx:165](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L165)
 
 ___
 
@@ -72,7 +79,7 @@ The row index.
 
 #### Defined in
 
-[components/TableBody.tsx:151](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L151)
+[components/TableBody.tsx:167](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L167)
 
 ___
 
@@ -84,7 +91,27 @@ Props to the `tr` element.
 
 #### Defined in
 
-[components/TableBody.tsx:162](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L162)
+[components/TableBody.tsx:178](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L178)
+
+___
+
+### validRowClickTagNames
+
+• `Optional` **validRowClickTagNames**: ``"*"`` \| `string`[]
+
+Customize the tag names that will trigger the row onClick. Defaults to ['TR', 'TD'].
+For more information, please visit the [tagName documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName).
+
+Other than an array of tag names, you can also pass a string "*" to indicate that all child elements
+will trigger the row on click event.
+
+#### Inherited from
+
+CommonProps.validRowClickTagNames
+
+#### Defined in
+
+[components/TableBody.tsx:26](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L26)
 
 ## Methods
 
@@ -107,4 +134,4 @@ Optional row on click event.
 
 #### Defined in
 
-[components/TableBody.tsx:153](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L153)
+[components/TableBody.tsx:169](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L169)

--- a/api/modules/components_TableBody.md
+++ b/api/modules/components_TableBody.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[components/TableBody.tsx:48](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L48)
+[components/TableBody.tsx:61](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L61)
 
 ## Functions
 
@@ -54,7 +54,7 @@ have matching search results.
 
 #### Defined in
 
-[components/TableBody.tsx:343](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L343)
+[components/TableBody.tsx:362](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L362)
 
 ___
 
@@ -83,7 +83,7 @@ such as `tr` and `td` tags.
 
 #### Defined in
 
-[components/TableBody.tsx:84](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L84)
+[components/TableBody.tsx:98](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L98)
 
 ___
 
@@ -128,4 +128,4 @@ The above snippet will render loading indicator for rows that don't have suffici
 
 #### Defined in
 
-[components/TableBody.tsx:185](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L185)
+[components/TableBody.tsx:201](https://github.com/imballinst/react-bs-datatable/blob/master/src/components/TableBody.tsx#L201)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bs-datatable",
-  "version": "3.11.2",
+  "version": "3.12.0-beta.0",
   "description": "React Bootstrap Datatable (without jQuery) with sorting, filter, and pagination",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/__stories__/00-Uncontrolled.stories.tsx
+++ b/src/__stories__/00-Uncontrolled.stories.tsx
@@ -12,7 +12,8 @@ import {
   HtmlTrProps,
   TableBody,
   TableBodyProps,
-  TableRow
+  TableRow,
+  TableRowProps
 } from '../components/TableBody';
 import {
   DatatableWrapper,
@@ -193,7 +194,11 @@ CustomThProps.argTypes = {
   }
 };
 
-export const RowOnClick = Template.bind({});
+const RowOnClickTemplate: ComponentStory<typeof RowOnClickStoryTable> = (
+  args
+) => <RowOnClickStoryTable {...args} />;
+
+export const RowOnClick = RowOnClickTemplate.bind({});
 RowOnClick.storyName = 'Adding row on click event';
 RowOnClick.argTypes = {
   rowOnClickText: {
@@ -476,7 +481,9 @@ function StoryTable({
   tableEventsRef,
   children,
   // Additional sort props.
-  sortProps = {}
+  sortProps = {},
+  // Valid row click tag names.
+  validRowClickTagNames
 }: {
   sortableFields?: string[];
   filterableFields?: string[];
@@ -511,6 +518,7 @@ function StoryTable({
   children?: ReactNode;
   // Additional sort props.
   sortProps?: DatatableWrapperProps<StoryColumnType>['sortProps'];
+  validRowClickTagNames?: TableRowProps<StoryColumnType>['validRowClickTagNames'];
 }) {
   const headers: TableColumnType<StoryColumnType>[] = STORY_HEADERS.map(
     (header) => ({
@@ -621,7 +629,61 @@ function StoryTable({
       </Row>
       <Table>
         <TableHeader />
-        <TableBody onRowClick={rowOnClick} rowProps={rowProps} />
+        <TableBody
+          onRowClick={rowOnClick}
+          rowProps={rowProps}
+          validRowClickTagNames={validRowClickTagNames}
+        />
+      </Table>
+    </DatatableWrapper>
+  );
+}
+
+// For row on click templates.
+function RowOnClickStoryTable({
+  // For on click row event.
+  rowOnClickText,
+  rowOnClickFn,
+  // Valid row click tag names.
+  validRowClickTagNames,
+  headers = STORY_HEADERS
+}: {
+  // For on click row event.
+  rowOnClickText?: string;
+  rowOnClickFn?: (
+    name: string,
+    event: React.MouseEvent<HTMLTableRowElement, MouseEvent>
+  ) => void;
+  validRowClickTagNames?: TableRowProps<StoryColumnType>['validRowClickTagNames'];
+  headers?: TableColumnType<StoryColumnType>[];
+}) {
+  let rowOnClick: TableBodyProps<StoryColumnType>['onRowClick'];
+
+  if (rowOnClickText) {
+    rowOnClick = (
+      row,
+      event: React.MouseEvent<HTMLTableRowElement, MouseEvent>
+    ) => {
+      alert(
+        `Clicked row containing name ${
+          row.name
+        }.\n\nYou inputted the text: ${rowOnClickText}. Clicked on element: ${
+          (event.target as any).tagName
+        }.`
+      );
+    };
+  } else if (rowOnClickFn) {
+    rowOnClick = (row, event) => rowOnClickFn(row.name, event);
+  }
+
+  return (
+    <DatatableWrapper body={json} headers={headers}>
+      <Table>
+        <TableHeader />
+        <TableBody
+          onRowClick={rowOnClick}
+          validRowClickTagNames={validRowClickTagNames}
+        />
       </Table>
     </DatatableWrapper>
   );

--- a/src/__stories__/00-Uncontrolled.test.tsx
+++ b/src/__stories__/00-Uncontrolled.test.tsx
@@ -13,7 +13,7 @@ import {
   ComposedTableRow
 } from './00-Uncontrolled.stories';
 import { StoryColumnType } from './resources/types';
-import { CheckboxState } from '../helpers/types';
+import { CheckboxState, TableColumnType } from '../helpers/types';
 
 describe('Basic use cases', () => {
   test('thProps', () => {
@@ -641,9 +641,10 @@ describe('Custom row on click', () => {
     rowsPerPage: 8,
     rowsPerPageOptions: [8, 16, 24, 32]
   };
-  const clickFn = jest.fn();
 
   test('custom score cell color when number is below 50', () => {
+    const clickFn = jest.fn();
+
     const { getByRole } = render(
       <RowOnClick {...DEFAULT_PROPS} rowOnClickFn={clickFn} />
     );
@@ -661,6 +662,80 @@ describe('Custom row on click', () => {
     expect(clickFn).toBeCalledTimes(1);
     expect(clickFn.mock.calls[0][0]).toBe('Aaren');
     expect(clickFn.mock.calls[0][1].target.tagName).toBe('TD');
+  });
+
+  test('custom validRowClickTagNames', () => {
+    const clickFn = jest.fn();
+
+    const headers: TableColumnType<StoryColumnType>[] = [
+      {
+        prop: 'name',
+        title: 'Name',
+        cell: (row) => <p>{row.name}</p>
+      },
+      {
+        prop: 'username',
+        title: 'Username'
+      },
+      {
+        prop: 'location',
+        title: 'Location'
+      },
+      {
+        prop: 'date',
+        title: 'Last Update'
+      },
+      {
+        prop: 'score',
+        title: 'Score'
+      }
+    ];
+
+    // Use P tag name.
+    let { getByText, rerender } = render(
+      <RowOnClick
+        {...DEFAULT_PROPS}
+        rowOnClickFn={clickFn}
+        headers={headers}
+        validRowClickTagNames={['P']}
+      />
+    );
+
+    let aarenText = getByText(/Aaren/);
+    aarenText.click();
+
+    expect(clickFn).toBeCalledTimes(1);
+    expect(clickFn.mock.calls[0][0]).toBe('Aaren');
+    expect(clickFn.mock.calls[0][1].target.tagName).toBe('P');
+
+    // Use all tag names.
+    rerender(
+      <RowOnClick
+        {...DEFAULT_PROPS}
+        rowOnClickFn={clickFn}
+        headers={headers}
+        validRowClickTagNames="*"
+      />
+    );
+
+    aarenText = getByText(/Aaren/);
+    aarenText.click();
+
+    expect(clickFn).toBeCalledTimes(2);
+    expect(clickFn.mock.calls[1][0]).toBe('Aaren');
+    expect(clickFn.mock.calls[1][1].target.tagName).toBe('P');
+
+    // Use the default one.
+    // Since "P" is not included inside ['TR', 'TD'], then nothing will happen.
+    rerender(
+      <RowOnClick {...DEFAULT_PROPS} rowOnClickFn={clickFn} headers={headers} />
+    );
+
+    aarenText = getByText(/Aaren/);
+    aarenText.click();
+
+    expect(clickFn).toBeCalledTimes(2);
+    expect(clickFn.mock.calls[2]).toBeUndefined();
   });
 });
 

--- a/src/components/TableBody.tsx
+++ b/src/components/TableBody.tsx
@@ -13,6 +13,19 @@ import {
   useCreateCheckboxHandlers
 } from '../helpers/hooks';
 
+const VALID_TAGS_FOR_ROW_ONCLICK = ['TD', 'TR'];
+
+interface CommonProps {
+  /**
+   * Customize the tag names that will trigger the row onClick. Defaults to ['TR', 'TD'].
+   * For more information, please visit the [tagName documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName).
+   *
+   * Other than an array of tag names, you can also pass a string "*" to indicate that all child elements
+   * will trigger the row on click event.
+   */
+  validRowClickTagNames?: '*' | string[];
+}
+
 export interface TableBodyLabels {
   /**
    * The text shown when there is no result, which can be because of
@@ -56,7 +69,8 @@ export type HtmlTrProps = Omit<
 /**
  * This is an interface for `TableBody` component props.
  */
-export interface TableBodyProps<TTableRowType extends TableRowType> {
+export interface TableBodyProps<TTableRowType extends TableRowType>
+  extends CommonProps {
   /** Customize the labels of the `TableBody` component. */
   labels?: TableBodyLabels;
   /** Customize the classes of the `TableBody` component. */
@@ -87,7 +101,8 @@ export function TableBody<TTableRowType extends TableRowType>({
   rowProps,
   onRowClick: onRowClickProp,
   controlledProps,
-  children
+  children,
+  validRowClickTagNames = VALID_TAGS_FOR_ROW_ONCLICK
 }: TableBodyProps<TTableRowType>) {
   const { data } = useDatatableWrapper();
   useControlledStateSetter(controlledProps);
@@ -115,6 +130,7 @@ export function TableBody<TTableRowType extends TableRowType>({
             rowProps={rowProps}
             classes={{ td: classes?.td, tr: classes?.tr }}
             controlledProps={controlledProps}
+            validRowClickTagNames={validRowClickTagNames}
             onRowClick={onRowClickProp}
           />
         );
@@ -139,12 +155,12 @@ export function TableBody<TTableRowType extends TableRowType>({
 }
 
 // Composing functions.
-const VALID_TAGS_FOR_ROW_ONCLICK = ['TD', 'TR'];
 
 /**
  * The props for the `TableRow` component.
  */
-export interface TableRowProps<TTableRowType extends TableRowType> {
+export interface TableRowProps<TTableRowType extends TableRowType>
+  extends CommonProps {
   /** The row data. */
   rowData: TTableRowType;
   /** The row index. */
@@ -188,7 +204,8 @@ export function TableRow<TTableRowType extends TableRowType>({
   onRowClick: onRowClickProp,
   classes,
   controlledProps,
-  rowProps
+  rowProps,
+  validRowClickTagNames = VALID_TAGS_FOR_ROW_ONCLICK
 }: TableRowProps<TTableRowType>) {
   const {
     headers,
@@ -203,10 +220,12 @@ export function TableRow<TTableRowType extends TableRowType>({
     event: React.MouseEvent<HTMLTableRowElement, MouseEvent>
   ) {
     if (typeof onRowClickProp === 'function') {
-      if (
-        event.target instanceof HTMLElement &&
-        VALID_TAGS_FOR_ROW_ONCLICK.includes(event.target.tagName)
-      ) {
+      const isValidTagName =
+        validRowClickTagNames === '*' ||
+        (event.target instanceof HTMLElement &&
+          validRowClickTagNames.includes(event.target.tagName));
+
+      if (isValidTagName) {
         onRowClickProp(rowData, event);
       }
     }


### PR DESCRIPTION
Closes #186.